### PR TITLE
Исправления румынских шагов

### DIFF
--- a/locales/Steps/Templates/ro/Ext/Template.xml
+++ b/locales/Steps/Templates/ro/Ext/Template.xml
@@ -120,10 +120,6 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Шаг оригинал</v8:content>
 						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Шаг оригинал</v8:content>
-						</v8:item>
 					</tl>
 				</c>
 			</c>
@@ -15512,13 +15508,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Bara secțiunii este egală
- | 'NumeElement1' |
- | 'NumeElement2' |</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
+<<<<<<< HEAD
 							<v8:content>Și Bara secțiunii este egală
+=======
+							<v8:content>Bara secțiunii este egală
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
  | 'NumeElement1' |
  | 'NumeElement2' |</v8:content>
 						</v8:item>
@@ -15573,11 +15567,6 @@
 						<v8:item>
 							<v8:lang>ru</v8:lang>
 							<v8:content>Și panoul secțiunilor conține elemente de meniu                                                                                           | 'NumeElement1' |
- | 'NumeElement2' |</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și panoul secțiunilor conține elemente de meniu                       | 'NumeElement1' |
  | 'NumeElement2' |</v8:content>
 						</v8:item>
 					</tl>
@@ -19182,10 +19171,6 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Și aștept ca grupul de pagini "%1 GrupPagini" să devină pagina curentă "%2 NumePagini" în timp de "%3 20" secunde</v8:content>
 						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și aștept ca grupul de pagini "%1 GrupPagini" să devină pagina curentă "%2 NumePagini" în timp de "%3 20" secunde</v8:content>
-						</v8:item>
 					</tl>
 				</c>
 			</c>
@@ -20037,11 +20022,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
+<<<<<<< HEAD
+							<v8:content>Și eu schimb valoarea comutatorului cu numele "%1 Titlul Elementului" pe "%2 Valoarea comutatorului" dupa șablon</v8:content>
+=======
 							<v8:content>Schimb valoarea comutatorului cu numele '%1 Titlul Elementului' pe '%2 Valoarea comutatorului' dupa șablon</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și eu schimb valoarea comutatorului cu numele '%1 Titlul Elementului' pe '%2 Valoarea comutatorului' dupa șablon</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -20091,11 +20076,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
+<<<<<<< HEAD
+							<v8:content>Și eu schimb valoarea comutatorului cu numele "%1 NumeElement" pe "%2 Valoarea comutatorului" după șablonul</v8:content>
+=======
 							<v8:content>Și schimba valoarea comutatorului cu numele '%1 NumeElement' pe '%2 Valoarea comutatorului' după șablonul</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și eu schimb valoarea comutatorului cu numele '%1 NumeElement' pe '%2 Valoarea comutatorului' după șablonul</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -20155,10 +20140,6 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Faceți clic pe buton pentru a deschide câmpul de introducere.</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
 							<v8:content>Faceți clic pe buton pentru a deschide câmpul de introducere.</v8:content>
 						</v8:item>
 					</tl>
@@ -25439,14 +25420,13 @@
 						<v8:item>
 							<v8:lang>ru</v8:lang>
 							<v8:content>Și în tabelul "%1 NumeTabel" eu trec la rândul:
-  | Denumire |
-  | Marfa1 |</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și în tabelul "%1 NumeTabel" eu trec la rândul:
+<<<<<<< HEAD
   | NumeColoana |
   | ValoareColoana |</v8:content>
+=======
+  | Denumire |
+  | Marfa1 |</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -25938,7 +25918,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Și în tabelul "%1 Partea tabelară1" eu butonez butonul cu numele "Adăugare"</v8:content>
+							<v8:content>Și în tabelul "%1 Partea tabelară" eu butonez butonul cu numele "%2 Adăugare"</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28397,10 +28377,6 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Și eu menționez valoarea câmpului "%1 Titlu Câmp" cu cheia "%2 Număr documentului" global</v8:content>
 						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și eu menționez valoarea câmpului "%1 Titlu Câmp" cu cheia "%2 Număr documentului" global</v8:content>
-						</v8:item>
 					</tl>
 				</c>
 			</c>
@@ -28438,10 +28414,6 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Сохранение значения поля таблицы в переменную Контекст</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>ro</v8:lang>
 							<v8:content>Сохранение значения поля таблицы в переменную Контекст</v8:content>
 						</v8:item>
 					</tl>
@@ -28581,10 +28553,6 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>И я меняю значение переключателя "%1 Заголовок элемента" на "%2 Значение переключателя"</v8:content>
 						</v8:item>
-						<v8:item>
-							<v8:lang>ro</v8:lang>
-							<v8:content>И я меняю значение переключателя "%1 Заголовок элемента" на "%2 Значение переключателя"</v8:content>
-						</v8:item>
 					</tl>
 				</c>
 			</c>
@@ -28605,15 +28573,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
+<<<<<<< HEAD
+							<v8:content>Și eu schimb valoarea radiobutonului "%1 Titlul element" la "%2 Valoare radiobutonului"</v8:content>
+=======
 							<v8:content>Și eu schimb valoarea radiobutonului "%1 Atribut radiobuton" la "%2 Prima valoare"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și eu schimb valoarea comutatorului "%1 Titlul element" la "%2 Valoare comutatorului"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>ro</v8:lang>
-							<v8:content>Și eu schimb valoarea comutatorului "%1 Atribut radiobuton" la "%2 Prima valoare“</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -28643,10 +28607,6 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>И я меняю значение переключателя с именем "%1 РеквизитПереключатель" на "%2 Значение переключателя"</v8:content>
 						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>И я меняю значение переключателя с именем "%1 РеквизитПереключатель" на "%2 Значение переключателя"</v8:content>
-						</v8:item>
 					</tl>
 				</c>
 			</c>
@@ -28667,15 +28627,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
+<<<<<<< HEAD
+							<v8:content>Și eu schimb valoarea radiobutonului cu numele "%1 Titlul element" la "%2 Valoare radiobutonului"</v8:content>
+=======
 							<v8:content>Și eu schimb valoarea radiobutonului cu numele "%1 Atributradiobuton" la "%2 Prima valoare"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și eu schimb valoarea comutatorului cu numele "%1 AtributComutator" la "%2 Valoare comutatorului"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>ro</v8:lang>
-							<v8:content>Și eu schimb valoarea comutatorului cu numele "%1 Atributradiobuton" la "%2 Prima valoare“</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -28724,11 +28680,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Și eu butonez selectarea câmpului "%1 Atribut2"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
+<<<<<<< HEAD
 							<v8:content>Și eu butonez selectarea câmpului "%1 Titlu Câmp"</v8:content>
+=======
+							<v8:content>Și eu butonez selectarea câmpului "%1 Atribut"</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -28777,11 +28733,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Și eu butonez golirea câmpului "%1 Selectare"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
+<<<<<<< HEAD
 							<v8:content>Și eu butonez golirea câmpului "%1 Titlu Câmp"</v8:content>
+=======
+							<v8:content>Și eu butonez golirea câmpului "%1 Selectare"</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -28831,15 +28787,11 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
+<<<<<<< HEAD
+							<v8:content>Și eu butonez golirea câmpului cu numele "%1 NumeCâmp"</v8:content>
+=======
 							<v8:content>Și eu butonez golirea câmpului cu numele "%1 Selectare"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și eu butonez golirea câmpului cu numele "%1 NumeCâmp"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>ro</v8:lang>
-							<v8:content>Și eu butonez golirea câmpului cu numele "%1 NumeCâmp"</v8:content>
+>>>>>>> 91a02e45196075969e5d1f6cfe3b96ad96ec9528
 						</v8:item>
 					</tl>
 				</c>
@@ -30915,10 +30867,6 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Și eu activez fereastră "%1 Titlu fereastra"</v8:content>
 						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Și eu activez fereastră "%1 Titlu fereastra"</v8:content>
-						</v8:item>
 					</tl>
 				</c>
 			</c>
@@ -32914,10 +32862,6 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Atunci textul celulei actuale din tabelul "%1 Tabel" a devenit egal cu "%2 Valoare câmp"</v8:content>
 						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
-							<v8:content>Atunci textul celulei actuale din tabelul "%1 Tabel" a devenit egal cu "%2 Valoare câmp"</v8:content>
-						</v8:item>
 					</tl>
 				</c>
 			</c>
@@ -32965,10 +32909,6 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Atunci textul celulei din Tabelul "%1 Tabel" "%2 NumeCâmp" a devenit egal cu "%3 Valoare câmp"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
 							<v8:content>Atunci textul celulei din Tabelul "%1 Tabel" "%2 NumeCâmp" a devenit egal cu "%3 Valoare câmp"</v8:content>
 						</v8:item>
 					</tl>
@@ -33116,10 +33056,6 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Atunci eu chem excluderea "%1 Textul excluderei"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>en</v8:lang>
 							<v8:content>Atunci eu chem excluderea "%1 Textul excluderei"</v8:content>
 						</v8:item>
 					</tl>
@@ -34114,10 +34050,6 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Și eu înlocuiesc valoarea comutatorului "%1 TitluElement" cu valoarea variabilei "%2 NumeVariabila"</v8:content>
-						</v8:item>
-						<v8:item>
-							<v8:lang>ro</v8:lang>
 							<v8:content>Și eu înlocuiesc valoarea comutatorului "%1 TitluElement" cu valoarea variabilei "%2 NumeVariabila"</v8:content>
 						</v8:item>
 					</tl>


### PR DESCRIPTION
Исправления румынских шагов:
- удаление переводов шагов из всех синонимов, кроме русского
- исправление ошибок