### PR TITLE
Обновление редактора VAEditor, версия 1.1.0.10

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -13,8 +13,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.1.0.9/VAEditor.zip",
-"hash": "4027F66A37DCD1B952A7E6ADBE7810C5E4DF55C615E90FD6924B61BC69A80832",
-"version": "1.1.0.9"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.1.0.10/VAEditor.zip",
+"hash": "98F5D41F448B7E661AEA513917427C586B58A4480F24C283A1E9B24BF376DA49",
+"version": "1.1.0.10"
 }
 ]


### PR DESCRIPTION
Исправление ошибок:
* Доступность в 1С метода закрытия вкладки
* Режим "только просмотр" для DiffEditor