### PR TITLE
Обновление редактора VAEditor, версия 1.1.0.11

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -13,8 +13,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.1.0.10/VAEditor.zip",
-"hash": "98F5D41F448B7E661AEA513917427C586B58A4480F24C283A1E9B24BF376DA49",
-"version": "1.1.0.10"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.1.0.11/VAEditor.zip",
+"hash": "35AAB31107FB7A56FF73BB3DA21094CD411E9A3773D7D9F7885896A8DEB787D9",
+"version": "1.1.0.11"
 }
 ]


### PR DESCRIPTION
Исправлена ошибка проверки синтаксиса для ключевых слов верхнего уровня, если вначале строки отступ.