### PR TITLE
Обновление редактора VAEditor, версия 1.2.0.19

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -13,8 +13,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.2.0.18/VAEditor.zip",
-"hash": "13748F1207A9F2A6632A59E242D6B5872144EDB34C159199239B187AD9E2D1D6",
-"version": "1.2.0.18"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.2.0.19/VAEditor.zip",
+"hash": "DEECB521F94A59E364E01C2A4D43EF95A6D51DE864422094A2197B7ED977665C",
+"version": "1.2.0.19"
 }
 ]


### PR DESCRIPTION
Исправлена ошибка с буквой Ё в ключевых словах редактора