### PR TITLE
Обновление компоненты VanessaExt, версия 1.2.3.197

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.2.3.179/AddIn.zip",
-"hash": "AE06D8E75301DA743811E6066D73C16F894D4F2A1920B098B9860C1E43C20512",
-"version": "1.2.3.179"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.2.3.197/AddIn.zip",
+"hash": "888802F81A694DA4E946F5B075FA73BF7F9BA5F9499391F38A567A3EEE27E13B",
+"version": "1.2.3.197"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Исправление для активации окна Windows и задержка при эмуляции двойного клика.

