### PR TITLE
Обновление редактора VAEditor, версия 1.2.0.28

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -22,8 +22,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.2.0.27/VAEditor.zip",
-"hash": "863128EFA718C155B4387CD1C5FFFD0698407A371187833F305241698897E7D2",
-"version": "1.2.0.27"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.2.0.28/VAEditor.zip",
+"hash": "14513ED3FA7FA9D749CF159BD5DA99A394F6164BA2C0472554FE792F7CFBF996",
+"version": "1.2.0.28"
 }
 ]


### PR DESCRIPTION
Исправлена ошибка свертывания строк, содержащих только одно ключевое слово