### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.2.16

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.1.13/AddIn.zip",
-"hash": "FC25960663F3DF920AC31789ECE81172C2C5F036FE78090F1A1B07804E2777CA",
-"version": "1.3.1.13"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.2.16/AddIn.zip",
+"hash": "ADC58E20B2CCABCD151424011C9FA66588E3E84BE9CCC8E3FD984EC0721F135A",
+"version": "1.3.2.16"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Исправлен парсер Gherkin для Linux