### PR TITLE
Обновление редактора VAEditor, версия 1.3.0.8

### DIFF
--- a/VanessaAutomation/Forms/УправляемаяФорма/Ext/Form/Module.bsl
+++ b/VanessaAutomation/Forms/УправляемаяФорма/Ext/Form/Module.bsl
@@ -42480,6 +42480,7 @@
 			VanessaEditor = view.createVanessaEditor("", "turbo-gherkin");
 			МодульРедакторТекста().УстановитьСписокКомандVanessaEditor();
 			VanessaEditor.setSuggestWidgetWidth("90%");
+			view.blockContextMenu1C();
 			view.createVanessaTabs();
 			VanessaTabs = Элементы.VanessaEditor.Document.defaultView.VanessaTabs;
 		КонецЕсли;	 

--- a/lib/packages.json
+++ b/lib/packages.json
@@ -22,8 +22,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.0.6/VAEditor.zip",
-"hash": "0003DD2732E989712BCAFE3FF2662DACD2DF54B71A8897DD800CB3792AD4D280",
-"version": "1.3.0.6"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.0.8/VAEditor.zip",
+"hash": "29E253EC8E6519529DCF4BCDD7E08DECC5106D5889E9B74341215B0D39233A52",
+"version": "1.3.0.8"
 }
 ]


### PR DESCRIPTION
При инициализации VAEditor можно заблокировать отображение контекстного меню 1С или VAEditor.

Добавлены глобальные методы редактора: blockContextMenu1C, blockContextMenuVA.
