### PR TITLE
Обновление редактора VAEditor, версия 1.3.3.13

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -22,8 +22,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.3.12/VAEditor.zip",
-"version": "1.3.3.12",
-"hash": "310D59865363FD81145C74CE71AA66F3AB71AEB7883BEECFBAD7618427D6CDD2"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.3.13/VAEditor.zip",
+"version": "1.3.3.13",
+"hash": "730F9155B71A96B8A6C34D9E5DA9047F327CF720746CB90C79D33753ABEE8801"
 }
 ]


### PR DESCRIPTION
Исправлена ошибка повторного открытия Markdown