### PR TITLE
Обновление редактора VAEditor, версия 1.3.4.22

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -22,8 +22,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.4.15/VAEditor.zip",
-"version": "1.3.4.15",
-"hash": "EA8A5B7CAEBAC7EC0EC207C098461C258AF3F7762782B21EBDE1E603F19F8BF8"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.4.22/VAEditor.zip",
+"version": "1.3.4.22",
+"hash": "1E6BD4F28D94826FC49A3477F90970D3C39F23686B8EE16DEA9733C0B940EEFB"
 }
 ]


### PR DESCRIPTION
Заблокировано включение скроллинга нажатием средней кнопки мыши мыши.
Нажатие средней кнопки мыши на вкладке редактора закрывает вкладку.
Сохранение позиции скроллинга при открытии нового файла.
Исправлены стили подчеркивания для темной схемы.