### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.6.16

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.6.9/AddIn.zip",
-"hash": "27B5A7A068EB910F0F560A45AF0F620CEF27AE15B3F64B6F58512C989DFB4AD0",
-"version": "1.3.6.9"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.6.16/AddIn.zip",
+"hash": "92B37D2D5935CFF92EAC2B3F837E001B0579CFAB3200F00E2304961B1F04AB1F",
+"version": "1.3.6.16"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Сборка для Linux на Ubuntu 18.04