### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.7.17

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.7.9/AddIn.zip",
-"hash": "7F3C0D74EAAF650860F86D18F6B7B78F21123E92E38170A0DF8622585D384592",
-"version": "1.3.7.9"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.7.17/AddIn.zip",
+"hash": "A931555980F8F7D088DA703ACF57726444A4A42446910764C107261765549DC1",
+"version": "1.3.7.17"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Парсер Gherkin: считаем дефис, точку и цифры идущие без пробела частью слова