### PR TITLE
Исправление ошибки в Подготовке и загрузке данных

### DIFF
--- a/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form/Module.bsl
+++ b/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form/Module.bsl
@@ -1687,7 +1687,7 @@ Function ItIsDataForUpload(Value)
 	
 	TypeVal = TypeOf(Value);
 			
-	If TypeVal = Undefined Then
+	If TypeVal = TypeOf(Undefined) Then
 		
 		Return False;
 		


### PR DESCRIPTION
Иногда в Value приходит значение типа Неопределено.
До моих изменений тип переменной сравнивался со *значением* Неопределено, теперь тип переменной сравнивается с *типом* Неопределено.

Если это не исправить, то при генерации фичи происходит вызов "Неопределено.Пустая()", что приводит к ошибке. Воспроизводится в 1.2.038.27.

@KrapivinAndrey 