### PR TITLE
ПодготовкаИЗагрузкаДанных: выбор по ссылкам объектов расширений

### DIFF
--- a/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form.xml
@@ -864,11 +864,7 @@
 							<v8:content>Объект</v8:content>
 						</v8:item>
 					</Title>
-					<Type>
-						<v8:TypeSet>cfg:DocumentRef</v8:TypeSet>
-						<v8:TypeSet>cfg:ChartOfCharacteristicTypesRef</v8:TypeSet>
-						<v8:TypeSet>cfg:CatalogRef</v8:TypeSet>
-					</Type>
+					<Type/>
 				</Column>
 				<Column name="IncludeDownstreamDependencies" id="2">
 					<Title>

--- a/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form/Module.bsl
+++ b/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form/Module.bsl
@@ -54,6 +54,38 @@ Function ПолучитьМакетОбработки(Val TemplateName) Export
 	Return GetTemplateAtServer(TemplateName);
 EndFunction
 
+&AtServer
+Procedure SetAttributTypes()
+	
+	TypesArray = New Array;
+	
+	MetadataTypeMap = GetMetadataTypeMap();
+	
+	For Each MetadataTypeItem In MetadataTypeMap Do
+		For Each MetadataObj In Metadata[MetadataTypeItem.Key] Do
+			TypesArray.add(StrTemplate("%1.%2", MetadataTypeItem.Value, MetadataObj.Name));	
+		EndDo;
+	EndDo;
+	
+	DataRefsTypeRestriction = New TypeDescription(StrConcat(TypesArray, ","));
+	
+	Items.DataRefsRef.TypeRestriction = DataRefsTypeRestriction;
+	
+EndProcedure
+
+&AtServer
+Function GetMetadataTypeMap()
+	
+	MetadataTypeMap = New Map;
+	
+	MetadataTypeMap.Insert("Catalogs",  "CatalogRef");
+	MetadataTypeMap.Insert("Documents", "DocumentRef");
+	MetadataTypeMap.Insert("ChartsOfCharacteristicTypes", "ChartOfCharacteristicTypesRef");
+	
+	Return MetadataTypeMap;
+	
+EndFunction
+
 #EndRegion
 
 #Region WorkWithScenarious
@@ -805,6 +837,7 @@ EndProcedure
 Procedure OnCreateAtServer(Cancel, StandardProcessing)	
 	
 	MaxDownstreamDependenciesHierarchyLevel = 1;
+	SetAttributTypes();	
 	
 EndProcedure
 


### PR DESCRIPTION
На вкладке "Отбор по ссылкам" невозможно выбрать ссылки на объекты, добавленные в расширениях, т.к. типы реквизита "СправочникСсылка", "ДокументСсылка", "ПланВидовХарактеристикСсылка" не включают в себя ссылки на объекты расширений.
Доработкой изменен тип реквизита на произвольный, с программной установкой ограничений на типы в методе ПриСозданииНаСервере.
