### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.8.34

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.8.33/AddIn.zip",
-"hash": "CBBA8C8AE98A9EB7377018BD5F2C28F1CB765B161F58F4BF2B6894CD85C4B7A8",
-"version": "1.3.8.33"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.8.34/AddIn.zip",
+"hash": "EC621F8646945C17B4E959ECC3089283D4E000CEFF7458B05622736745A91ADF",
+"version": "1.3.8.34"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Поиск клиента тестирования как обычного приложения