### PR TITLE
fix: теперь работает загрузка регистров сведений в режиме обмен данными Истина

### DIFF
--- a/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form/Module.bsl
+++ b/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form/Module.bsl
@@ -767,7 +767,7 @@ Procedure ICheckOrCreateInformationRegisterRecordsWithDataExchangeLoadTrue(Val R
 		
 	Else
 		
-		ICheckOrCreateInformationRegisterRecordsAtServer(RegisterName, Values, False, True);
+		ICheckOrCreateInformationRegisterRecordsAtServer(RegisterName, Values, True, True);
 		
 	EndIf;
 		


### PR DESCRIPTION
реализация  #1837

Принудительно вызываем вариант подготовки данных не через менеджер записи, а через набор записей, который уже был реализован.