### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.9.12

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.10/AddIn.zip",
-"hash": "E901AC39FDC33438F43DBDC2470063A5BABDB548246F3535F96B0B77D0F8A2A8",
-"version": "1.3.9.10"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.12/AddIn.zip",
+"hash": "E6AA9051DFE026B5F4A642F2D183C0FB535B990144D77590377FD30E2A0D67D8",
+"version": "1.3.9.12"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
В версии внешней компоненты для Linux отключена библиотека libgit2
https://github.com/lintest/VanessaExt/issues/71