### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.9.22

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.21/AddIn.zip",
-"hash": "6F2377EA5CBF64685E6FF0DE3E5D8F9E8A6C9BCB0A9E22764173A7A9A1FBF5D8",
-"version": "1.3.9.21"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.22/AddIn.zip",
+"hash": "69F53030928D3AE1B72AE8612AA4359C470F5AEB84FCBFB4A09756A3930BB21F",
+"version": "1.3.9.22"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Сборка версии для Linux на Ubuntu 18.04