### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.9.26

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.25/AddIn.zip",
-"hash": "E26A2A6167FF1C7BD60074AFA579AD9793862526C39463017000FF69E21A41A6",
-"version": "1.3.9.25"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.26/AddIn.zip",
+"hash": "3690C64FD6C106C30FC1FAC27AA06E4BC488BB1B5A9021980414B4B12B214B5C",
+"version": "1.3.9.26"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
При получении сведений о процессах для Linux не возвращаем CreationDate из-за ошибки чтения JSON