### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.9.95

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.91/AddIn.zip",
-"hash": "5E2E07C8A6D3F7E7645A7CFDAD5C6213C64B9F5FF679361585493E824C50021A",
-"version": "1.3.9.91"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.95/AddIn.zip",
+"hash": "8741E02FAE981C61C7DADB429E2A823CD0D6B9FE446DB07188F51A517DDA6A7B",
+"version": "1.3.9.95"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Для версии 8.5 исправлен метод ПолучитьСнимокПроцесса() https://github.com/lintest/VanessaExt/issues/85