### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.9.101

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.95/AddIn.zip",
-"hash": "8741E02FAE981C61C7DADB429E2A823CD0D6B9FE446DB07188F51A517DDA6A7B",
-"version": "1.3.9.95"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.101/AddIn.zip",
+"hash": "A8E15F5EA7B0A19BC9D0F790923F6F764E804CDD5E2BDADF01945C7F45D7FEC6",
+"version": "1.3.9.101"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Исправление ошибки https://github.com/lintest/VanessaExt/issues/91 Черная полоса вместо скриншота