### PR TITLE
Improve Swedish (sv) UI localization

### DIFF
--- a/VanessaAutomation.xml
+++ b/VanessaAutomation.xml
@@ -22,6 +22,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Vanessa Automation</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Vanessa Automation</v8:content>
+				</v8:item>
 			</Synonym>
 			<Comment/>
 			<DefaultForm>ExternalDataProcessor.VanessaAutomation.Form.ЧтениеПараметровПриОткрытии</DefaultForm>
@@ -39,6 +43,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Debug log</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Felsökningslogg</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -82,6 +90,10 @@
 							<v8:lang>vi</v8:lang>
 							<v8:content>Phiên bản của nền tảng cho tạo ra kiểm tra</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Plattformsversion för EPF-generering</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -124,6 +136,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate epf</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera EPF</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -161,6 +177,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Address of custom settings</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Adress för anpassade inställningar</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -203,6 +223,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Address data error</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Adressdatafel</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -360,6 +384,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Show module text instead of EPF regeneration</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa modultext istället för EPF-omgenerering</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -397,6 +425,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Download scenario fulfillment statuses to file</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ladda ner scenariokörningsstatus till fil</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -436,6 +468,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Run scenario from notification handler</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör scenario från notifieringshanterare</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -473,6 +509,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Run data processor upon opening</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör dataprocessor vid öppning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -512,6 +552,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Run scenarios after downloading features</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör scenarier efter nedladdning av features</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -549,6 +593,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Run scenarios after downloading features once</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör scenarier efter nedladdning av features en gång</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -588,6 +636,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Run steps asynchronously</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör steg asynkront</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -626,6 +678,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate managed form</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera hanterat formulär</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -663,6 +719,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Test suites grouping</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Gruppering av testsviter</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -705,6 +765,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Write scenarios execution to event log</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skriv scenariokörning till händelselogg</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -858,6 +922,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate JSON for every error</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera JSON för varje fel</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -895,6 +963,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate report in internal format</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera rapport i internt format</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -934,6 +1006,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate report in cucumber json format</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera rapport i Cucumber JSON-format</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -971,6 +1047,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate report in jUnit format</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera rapport i JUnit-format</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1010,6 +1090,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate report in Allure format</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera rapport i Allure-format</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1022,6 +1106,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Create a scenario execution report in Allure format.</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skapa en scenariokörningsrapport i Allure-format.</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -1052,6 +1140,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate report in ASDS format</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera rapport i ASDS-format</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1091,6 +1183,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Take screenshot in case of errors or on demand</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ta skärmbild vid fel eller på begäran</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1129,6 +1225,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Translitarate messages</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Translitterera meddelanden</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1166,6 +1266,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Tests tree</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Testträd</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1323,6 +1427,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Add uploading conditions to scenario name</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägg till uppladdningsvillkor till scenarionamn</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1360,6 +1468,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Add meta information when clicking</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägg till metainformation vid klick</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1399,6 +1511,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Additional parameters</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ytterligare parametrar</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type/>
@@ -1434,6 +1550,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>There is support of the function to decompose a string to an array of substrings</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Det finns stöd för funktionen att dela upp en sträng i en array av delsträngar</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1473,6 +1593,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Exit the system after completing all scenarios</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Avsluta systemet efter att alla scenarier har slutförts</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1510,6 +1634,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Download features upon opening</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ladda features vid öppning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1553,6 +1681,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Close test client after running scenarios</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stäng testklienten efter att scenarier har körts</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1591,6 +1723,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Close the form after executing the data processor</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stäng formuläret efter att dataprocessorn har körts</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1628,6 +1764,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Voice (Amazon)</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Röst (Amazon)</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1671,6 +1811,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Engine</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Motor</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1712,6 +1856,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Access key</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Åtkomstnyckel</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -1755,6 +1903,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Secret key</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Hemlig nyckel</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1797,6 +1949,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Language (Amazon)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Språk (Amazon)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1837,6 +1993,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Region</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Region</v8:content>
 						</v8:item>
 					</Synonym>
@@ -1881,6 +2041,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Oauth token</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>OAuth-token</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1923,6 +2087,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Voice (Yandex)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Röst (Yandex)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -1949,6 +2117,13 @@
 
 - Female voices: Alyss, Jane, Oksana and Omazh.
 - Male voices: Zahar и Ermil.</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Syntetiserad talröst.
+
+- Kvinnliga röster: Alyss, Jane, Oksana och Omazh.
+- Manliga röster: Zahar och Ermil.</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -1979,6 +2154,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Directory ID</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog-ID</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2022,6 +2201,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Speed (Yandex)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Hastighet (Yandex)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2064,6 +2247,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Emotion</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Känsla</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2120,6 +2307,10 @@
 							<v8:lang>ro</v8:lang>
 							<v8:content>Limba</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Språk</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2161,6 +2352,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Request option</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Förfrågningsalternativ</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2212,6 +2407,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Api Key</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>API-nyckel</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2253,6 +2452,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Music volume</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Musikvolym</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2297,6 +2500,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Step group as step (video)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Steggrupp som steg (video)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2334,6 +2541,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video overlap TTS </v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Överlappa TTS vid videoinspelning </v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2373,6 +2584,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Add music to file with feature title</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägg till musik till fil med feature-titel</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2410,6 +2625,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Add music to final slide</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägg till musik till sista bilden</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2449,6 +2668,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Add subtitiles</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägg till undertexter</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2465,6 +2688,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Adds subtitles with details of the steps being executed to the video</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägger till undertexter med detaljer om de steg som körs till videon</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -2495,6 +2722,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Replace slide with feature title with video</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ersätt bild med feature-titel med video</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2534,6 +2765,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Replace final slide with video</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ersätt sista bilden med video</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2571,6 +2806,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video TTS name</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>TTS-namn för videoinspelning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2613,6 +2852,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Video recording tool</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Verktyg för videoinspelning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2661,6 +2904,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video temporary files directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för tillfälliga videoinspelningsfiler</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2681,6 +2928,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>The directory where files will be stored during video tutorials generation.</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalogen där filer lagras under generering av videohandledningar.</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -2711,6 +2962,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video music directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Musikkatalog för videoinspelning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2754,6 +3009,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video frames amount</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Antal bildrutor för videoinspelning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2796,6 +3055,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video convert command</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kommando för videokonvertering</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2844,6 +3107,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video FFmpeg command</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kommando för videoinspelning FFmpeg</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2868,6 +3135,12 @@
 							<v8:content>Video running and processing command. Also you can specify a full path to ffmpeg.exe file   
 
 Default: ffmpeg</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kommando för videokörning och bearbetning. Du kan även ange en fullständig sökväg till ffmpeg.exe   
+
+Standard: ffmpeg</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -2898,6 +3171,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video command start video recording</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kommando för att starta videoinspelning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -2941,6 +3218,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Video inset cache</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Cache för videoinfogningar</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -2983,6 +3264,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Cache video inserts</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Cachelagra videoinfogningar</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3020,6 +3305,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Cache voiceovers</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Cachelagra berättarröster</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3063,6 +3352,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>TTS files cache</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>TTS-filcache</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3111,6 +3404,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disable steps time scaling</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktivera tidsskalning för steg</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3149,6 +3446,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disable slide with feature title</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktivera bild med feature-titel</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3165,6 +3466,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disables video tutorial slide at the beginning of the video with information from the "Functionality" block of feature file</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktiverar videoinstruktionsbilden i början av videon med information från "Funktionalitet"-blocket i feature-filen</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -3196,6 +3501,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disable scenario slide</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktivera scenariobild</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3212,6 +3521,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disables the video tutorial slide with scenario title details</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktiverar videoinstruktionsbilden med scenariotiteldetaljer</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -3243,6 +3556,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disable final slide</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktivera sista bilden</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3259,6 +3576,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disables video tutorial slide at the end of the video with information about scenario build</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktiverar videoinstruktionsbilden i slutet av videon med information om scenariobygge</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -3289,6 +3610,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video move the mouse pointer to the active form item</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Flytta muspekaren till aktivt formulärobjekt vid videoinspelning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3328,6 +3653,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video highlight active form items</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Markera aktiva formulärobjekt vid videoinspelning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3365,6 +3694,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Highlight mouse click</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Markera musklick</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3404,6 +3737,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video show mouse pointer</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa muspekare vid videoinspelning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3441,6 +3778,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Acceleration percentage</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Accelerationsprocent</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3485,6 +3826,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video path to TTS engine</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg till TTS-motor för videoinspelning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3526,6 +3871,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Path to video file with feature title</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg till videofil med feature-titel</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3569,6 +3918,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Path to the video file of the final slide</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg till videofilen för sista bilden</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3610,6 +3963,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Speed</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Hastighet</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3654,6 +4011,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Hide service windows</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Dölj servicefönster</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3692,6 +4053,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video replacements dictionary</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ersättningsordbok för videoinspelning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3729,6 +4094,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Voice acting type</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Typ av berättarröst</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3773,6 +4142,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video file watermark</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Videoinspelning filens vattenstämpel</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3814,6 +4187,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video file mouse pointer</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Videoinspelning filens muspekare</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -3861,6 +4238,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>ro</v8:lang>
 							<v8:content>HTML</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>HTML</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3903,6 +4284,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>ro</v8:lang>
 							<v8:content>Markdown</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Markdown</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -3939,6 +4324,10 @@ Default: ffmpeg</v8:content>
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Video</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Video</v8:content>
 						</v8:item>
 					</Synonym>
@@ -3978,6 +4367,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video screen height</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Videoinspelning skärmhöjd</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4022,6 +4415,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video screen width</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Videoinspelning skärmbredd</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4064,6 +4461,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video left screen side</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Videoinspelning vänster skärmsida</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4108,6 +4509,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video screen top</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Videoinspelning skärmens överkant</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4151,6 +4556,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Emulate keyboard input</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Emulera tangentbordsinmatning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4189,6 +4598,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Emulate mouse movements</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Emulera musrörelser</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4226,6 +4639,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>TTS engine processing path</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg för TTS-motorbearbetning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4268,6 +4685,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Run TestClient with maximize window</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör testklient med maximerat fönster</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4421,6 +4842,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Run from command line</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör från kommandorad</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4458,6 +4883,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Running scenarios</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kör scenarier</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4497,6 +4926,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Recording the video</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Spela in video</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4533,6 +4966,10 @@ Default: ffmpeg</v8:content>
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>RunID</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>RunID</v8:content>
 						</v8:item>
 					</Synonym>
@@ -4577,6 +5014,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Directory for errors in json format</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för fel i JSON-format</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4618,6 +5059,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Current build name</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Aktuellt byggnamn</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4661,6 +5106,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>File name of external framework commands</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Filnamn för externa ramverkskommandon</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4702,6 +5151,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Text log file</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Textloggfil</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4864,6 +5317,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Step interval defined by user</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegintervall definierat av användare</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4907,6 +5364,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Search for form items by names</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sök formulärobjekt efter namn</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -4944,6 +5405,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use Sikulix server</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd SikuliX-server</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -4983,6 +5448,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use an add-in for screenshots</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd ett tillägg för skärmbilder</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5021,6 +5490,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Enable use of the VanessaExt component</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Aktivera användning av VanessaExt-komponenten</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5058,6 +5531,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Allure export directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Allure-exportkatalog</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -5101,6 +5578,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Base allure export directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bas-Allure-exportkatalog</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5142,6 +5623,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Cucumber json download directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Cucumber JSON-nedladdningskatalog</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -5185,6 +5670,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>JUnit Export directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>JUnit-exportkatalog</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5226,6 +5715,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>HTML tutorial export directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>HTML-handledningsexportkatalog</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -5269,6 +5762,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Markdown tutorial export directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Markdown-handledningsexportkatalog</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5310,6 +5807,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Video tutorial export directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Exportkatalog för videohandledning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -5353,6 +5854,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Screenshots export directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Exportkatalog för skärmbilder</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5394,6 +5899,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>ASDS downloads directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>ASDS-nedladdningskatalog</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -5437,6 +5946,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generated pictures directory </v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för genererade bilder </v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5479,6 +5992,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Library directories</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bibliotekskataloger</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5495,6 +6012,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Library files directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för biblioteksfiler</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -5530,6 +6051,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>vi</v8:lang>
 							<v8:content>Thư mục công cụ</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Verktygskatalog</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5550,6 +6075,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Root directory for additional framework files. By default, it is a directory for the main VA data processor.</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Rotkatalog för ytterligare ramverksfiler. Som standard är det katalogen för huvudbehandlingen VA.</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -5580,6 +6109,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>SikuliX scripts directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>SikuliX-skriptkatalog</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -5623,6 +6156,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Sources directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Källkatalog</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5664,6 +6201,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Root directory to build a hierarchy</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Rotkatalog för att bygga en hierarki</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -5830,6 +6371,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Features directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Feature-katalog</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -5990,6 +6535,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Number of action execution attempts</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Antal försök att köra åtgärd</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -6032,6 +6581,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Window search time in seconds</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Söktid för fönster i sekunder</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -6194,6 +6747,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Create Screenshot command</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kommando för att skapa skärmbild</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -6236,6 +6793,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Steps from metadata</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Steg från metadata</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -6252,6 +6813,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Library metadata</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Biblioteksmetadata</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -6282,6 +6847,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Refresh tree on scenario execution start</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Uppdatera träd vid start av scenariokörning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -6320,6 +6889,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Update script execution statistics</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Uppdatera skriptkörningsstatistik</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -6473,6 +7046,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Pause on opening window</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Paus vid öppning av fönster</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -6515,6 +7092,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Plugins</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Tillägg</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -6734,6 +7315,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Custom settings provider</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Leverantör av anpassade inställningar</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -6775,6 +7360,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Equate Pending to Failed</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Likställ Pending med Failed</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -6847,6 +7436,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Path to the file for unloading the script execution status</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg till fil för att exportera skriptkörningsstatus</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -7170,6 +7763,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generated scenario</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Genererat scenario</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -7364,6 +7961,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Collect data about the active form state when an error occurs</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Samla in data om aktivt formulärstatus vid fel</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -7401,6 +8002,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Collect status data for all forms on error</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Samla in statusdata för alla formulär vid fel</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -7541,6 +8146,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Create a video tutorial</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skapa en videohandledning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -7953,6 +8562,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Timeout for asynchronous steps</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Timeout för asynkrona steg</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -7996,6 +8609,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Test client startup timeout</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Timeout för testklientstart</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment>Таймаут запуска TestClient в секундах</Comment>
 					<Type>
@@ -8038,6 +8655,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Tree tag is enabled by default</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Trädtagg är aktiverad som standard</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -8255,6 +8876,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Report level 1</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Rapportnivå 1</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8297,6 +8922,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Report level 2</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Rapportnivå 2</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8338,6 +8967,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Report level 3</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Rapportnivå 3</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -8499,6 +9132,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach event log to allure report</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga händelselogg till Allure-rapport</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8536,6 +9173,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach active form state info to allure report</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga info om aktivt formulärstatus till Allure-rapport</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -8575,6 +9216,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach all forms state info to allure report</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga statusinfo för alla formulär till Allure-rapport</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8612,6 +9257,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Collect data about network connections</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Samla in data om nätverksanslutningar</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -8651,6 +9300,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Collect data about OS processes</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Samla in data om OS-processer</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8688,6 +9341,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach network connection info to allure report</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga nätverksanslutningsinfo till Allure-rapport</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -8727,6 +9384,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach OS processes data to allure report</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga OS-processdata till Allure-rapport</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8764,6 +9425,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Tags skipping script</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skript för att hoppa över taggar</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -8807,6 +9472,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Browser launch command</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kommando för webbläsarstart</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8849,6 +9518,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use browser + web socket</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd webbläsare + websocket</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8886,6 +9559,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Emulate mouse actions</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Emulera musåtgärder</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -8925,6 +9602,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Emulate keyboard input</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Emulera tangentbordsinmatning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -8962,6 +9643,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Ignore errors of browser elements search</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ignorera fel vid sökning av webbläsarelement</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9001,6 +9686,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach variable values info to allure report</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga variabelvärdesinfo till Allure-rapport</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9038,6 +9727,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Screen scaling factor</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skärmskalningsfaktor</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9082,6 +9775,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Record video of test session</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Spela in video av testsession</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9119,6 +9816,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Number of frames when recording video of test execution</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Antal bildrutor vid videoinspelning av testkörning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9163,6 +9864,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Video recording command</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kommando för videoinspelning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9204,6 +9909,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Directory for recording video of test execution</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för videoinspelning av testkörning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9280,6 +9989,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Test run</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Testkörning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9437,6 +10150,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Safe steps fulfillment (deprecated)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Säker stegkörning (föråldrad)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9478,6 +10195,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>vi</v8:lang>
 							<v8:content>Phiên bản bộ cài đặt</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Distributionspaketversion</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9521,6 +10242,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use Vanessa Editor</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd Vanessa Editor</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9558,6 +10283,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Vanessa Editor theme</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Vanessa Editor-tema</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9601,6 +10330,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use current form data when selecting steps in the editor</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd aktuell formulärdata vid val av steg i redigeraren</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9639,6 +10372,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show subscript lines in editor</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa understreckslinjer i redigeraren</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9676,6 +10413,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Horizontal offset</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Horisontell förskjutning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9720,6 +10461,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Vertical offset</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Vertikal förskjutning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9763,6 +10508,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Highlight mouse clicks in browser</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Markera musklick i webbläsare</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9800,6 +10549,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Number of steps</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Antal steg</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9844,6 +10597,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Timeout between steps when moving the mouse</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Timeout mellan steg vid musförflyttning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9887,6 +10644,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Service parameters</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Serviceparametrar</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type/>
@@ -9922,6 +10683,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show code thumbnail in editor</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa kodminiatyr i redigeraren</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -9961,6 +10726,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Do Sleep using Ping</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Gör Sleep med Ping</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -9999,6 +10768,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Replace tabs with spaces</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ersätt tabbar med mellanslag</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10036,6 +10809,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Mouse click highlight color</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Färg för musklicksmarkering</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10080,6 +10857,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Mouse click highlight radius</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Radie för musklicksmarkering</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10122,6 +10903,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Mouse click highlight duration</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Varaktighet för musklicksmarkering</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10166,6 +10951,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Mouse click highlight width</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bredd för musklicksmarkering</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10208,6 +10997,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Mouse click highlight transparency</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Transparens för musklicksmarkering</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10252,6 +11045,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Force close test client</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Tvångsstäng testklienten</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10289,6 +11086,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Timeout before forcibly closing test client</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Timeout innan tvångsstängning av testklient</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10333,6 +11134,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Detailed execution log</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Detaljerad körningslogg</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10370,6 +11175,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Sound notification when script ends</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ljudnotifiering när skriptet slutar</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10409,6 +11218,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show bookmarks on top</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa bokmärken överst</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10446,6 +11259,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Syntax checking in the editor</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Syntaxkontroll i redigeraren</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10485,6 +11302,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show differences in editor separately (two columns)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa skillnader i redigeraren separat (två kolumner)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10522,6 +11343,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Finding pictures using a addin VanessaExt</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Hitta bilder med tillägget VanessaExt</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10561,6 +11386,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Output log in console</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skriv ut logg i konsol</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10598,6 +11427,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Set variable values in steps</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ställ in variabelvärden i steg</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10637,6 +11470,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Server value</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Servervärde</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment>Специальный реквизит, в который можно сохранить результат вычислений на сервере, чтобы потом прочитать его на клиенте.</Comment>
 					<Type/>
@@ -10651,6 +11488,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>A special attribute in which you can save the result of calculations on the server in order to later read it on the client.</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ett speciellt attribut där du kan spara resultatet av beräkningar på servern för att senare läsa det på klienten.</v8:content>
 						</v8:item>
 					</ToolTip>
 					<MarkNegatives>false</MarkNegatives>
@@ -10681,6 +11522,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Equal pending to failed</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Likställ väntande med misslyckad</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10720,6 +11565,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use the Gherkin parser from the VanessaExt addin</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd Gherkin-parsern från VanessaExt-tillägget</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10757,6 +11606,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Displaying tabs and spaces</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa tabbar och mellanslag</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10801,6 +11654,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>autonumberingofsteps</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>autonumreringavsteg</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10838,6 +11695,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Update form tables when getting value</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Uppdatera formulärtabeller vid hämtning av värde</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10877,6 +11738,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Get layouts using extension VAExtension</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Hämta layouter med tillägget VAExtension</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10914,6 +11779,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach mxl files to allure report</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga mxl-filer till Allure-rapport</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -10953,6 +11822,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach mxl files saved in HTML format to Allure report</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga mxl-filer sparade i HTML-format till Allure-rapport</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -10990,6 +11863,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach additional data when comparing value with reference</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga ytterligare data vid jämförelse av värde med referens</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11029,6 +11906,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Start test client session again on connection if it's process is not found</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Starta testklientsession igen vid anslutning om dess process inte hittas</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11066,6 +11947,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Test client process start interval</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Startintervall för testklientprocess</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11110,6 +11995,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use UI Automation</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd UI Automation</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11147,6 +12036,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Voice</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Röst</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11190,6 +12083,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Client ID</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Klient-ID</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11231,6 +12128,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Client secret</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Klienthemlighet</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11308,6 +12209,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Sound script execution in real time</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ljud vid skriptkörning i realtid</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11345,6 +12250,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Modal window when starting test client is error</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Modalt fönster vid start av testklient är fel</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11384,6 +12293,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Evaluate expressions in curly braces (without Variables section)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Utvärdera uttryck inom klammerparenteser (utan avsnittet Variabler)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11422,6 +12335,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Collect data on variable values</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Samla in data om variabelvärden</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11459,6 +12376,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Path to adb</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg till adb</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11502,6 +12423,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show window for stopping script execution</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa fönster för att stoppa skriptkörning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11540,6 +12465,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show variable values in editor</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa variabelvärden i redigeraren</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11577,6 +12506,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Voice acting cache directory for online help</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Cachekatalog för berättarröst för onlinehjälp</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11620,6 +12553,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Create voiceovers for online help</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skapa berättarröster för onlinehjälp</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11657,6 +12594,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show window to stop recording user actions</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa fönster för att stoppa inspelning av användaråtgärder</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11696,6 +12637,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Open start page at startup</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Öppna startsida vid start</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11733,6 +12678,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Picture search threshold</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Tröskelvärde för bildsökning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11777,6 +12726,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Connect a hotkey to get help about current item</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Anslut en snabbtangent för hjälp om aktuellt objekt</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11814,6 +12767,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Determine the real port on which the testing client was launched</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bestäm den verkliga porten som testklienten startades på</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11853,6 +12810,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Distinguish between Broken or Failed by Then keyword</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skilja mellan Broken eller Failed med Then-nyckelord</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11890,6 +12851,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Scenario run</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Scenariokörning</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -11929,6 +12894,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Close interactive help script after execution</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stäng interaktivt hjälpskript efter körning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -11966,6 +12935,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show helper on first launch</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa hjälpare vid första start</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12005,6 +12978,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Attach xlsx files to allure report</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bifoga xlsx-filer till Allure-rapport</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12043,6 +13020,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Searching for files using the VanessaExt component</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Söka efter filer med VanessaExt-komponenten</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12080,6 +13061,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Html instruction Styles</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>HTML-instruktionsstilar</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12123,6 +13108,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Directory of service message output files</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för servicemeddelande-utdatafiler</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12165,6 +13154,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disable scheduled jobs execution for file infobase</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktivera schemalagda jobb för filinformationsbas</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12202,6 +13195,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>On clicking escape in the editor, close the form</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stäng formuläret vid tryck på Escape i redigeraren</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12241,6 +13238,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Step group as step (text)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Steggrupp som steg (text)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12278,6 +13279,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Add feature name to text instruction</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägg till feature-namn i textinstruktion</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12317,6 +13322,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Add scenario name to text instruction</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lägg till scenarionamn i textinstruktion</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12354,6 +13363,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Start lesson</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Starta lektion</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12393,6 +13406,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Video lessons</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Videolektioner</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12429,6 +13446,10 @@ Default: ffmpeg</v8:content>
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>PDF</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>PDF</v8:content>
 						</v8:item>
 					</Synonym>
@@ -12469,6 +13490,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>MD</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>MD</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12507,6 +13532,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use Template for New Feature</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd mall för ny feature</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12544,6 +13573,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Directory of new feature template</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för ny feature-mall</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12587,6 +13620,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Take browser screenshots</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ta skärmbilder av webbläsare</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12624,6 +13661,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Quit if silent installation add-in fails</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Avsluta om tyst installation av tillägg misslyckas</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12663,6 +13704,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Use a file to stop script execution</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd en fil för att stoppa skriptkörning</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12701,6 +13746,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Enable HTML voiceover</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Aktivera HTML-berättarröst</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12738,6 +13787,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>HTML voice-over tempo</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>HTML-berättarröst-tempo</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12782,6 +13835,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>HTML voiceover range</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>HTML-berättarröst-omfång</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12825,6 +13882,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>HTML voiceover voice</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>HTML-berättarröst</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12867,6 +13928,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Only one test client allowed to run</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Endast en testklient tillåts att köras</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12905,6 +13970,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Checking server calls in event handlers</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kontrollera serveranrop i händelsehanterare</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -12942,6 +14011,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Number of attempts to execute the script</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Antal försök att köra skriptet</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -12984,6 +14057,10 @@ Default: ffmpeg</v8:content>
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>VariantsHTMLInstructions</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>VariantsHTMLInstructions</v8:content>
 						</v8:item>
 					</Synonym>
@@ -13029,6 +14106,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Number of the first script to run</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Nummer på det första skriptet att köra</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13072,6 +14153,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Write scripts in jUnit via TestSuite</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skriv skript i JUnit via TestSuite</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13109,6 +14194,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Language of steps</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegspråk</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13152,6 +14241,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Clear output directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Rensa utdatakatalog</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13189,6 +14282,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Output directory</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Utdatakatalog</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13232,6 +14329,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Exception files directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för undantagsfiler</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13274,6 +14375,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Only entered objects for advanced actions</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Endast inmatade objekt för avancerade åtgärder</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13312,6 +14417,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Only changed relative to vendor configuration</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Endast ändrat relativt leverantörskonfiguration</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13349,6 +14458,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Vendor Configuration Name</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Leverantörskonfigurationsnamn</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13392,6 +14505,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Path to script settings file</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg till skriptinställningsfil</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13434,6 +14551,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Smoke tests sort documents by desc date sort in descending order</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Röktest sortera dokument efter fallande datum</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13471,6 +14592,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Smoke tests the starting date for the selection of documents</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Röktest startdatum för urval av dokument</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13512,6 +14637,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Maximum execution time action</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Maximal körtid för åtgärd</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13556,6 +14685,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Configuration name</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Konfigurationsnamn</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13597,6 +14730,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Configuration version</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Konfigurationsversion</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13640,6 +14777,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>System temporary files directory</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Katalog för systemets tillfälliga filer</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13682,6 +14823,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Mask the password in the log</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Maskera lösenordet i loggen</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13719,6 +14864,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Disable the ability for fields to overwrite text during a server call</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inaktivera möjligheten för fält att skriva över text under ett serveranrop</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13758,6 +14907,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Features to run</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Features att köra</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13795,6 +14948,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Processes for taking screenshots</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Processer för att ta skärmbilder</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13838,6 +14995,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Additional parameters for launching the testing client</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ytterligare parametrar för att starta testklienten</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13879,6 +15040,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Login (1C)</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inloggning (1C)</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -13922,6 +15087,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Password (1C, file path)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lösenord (1C, filsökväg)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -13963,6 +15132,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Key (1C)</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Nyckel (1C)</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -14006,6 +15179,10 @@ Default: ffmpeg</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Voice (1C)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Röst (1C)</v8:content>
+						</v8:item>
 					</Synonym>
 					<Comment/>
 					<Type>
@@ -14047,6 +15224,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Speech rate (1C)</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Talhastighet (1C)</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>
@@ -14090,6 +15271,10 @@ Default: ffmpeg</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>List of excluded allure variables</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Lista över exkluderade Allure-variabler</v8:content>
 						</v8:item>
 					</Synonym>
 					<Comment/>

--- a/VanessaAutomation/Forms/ВводСтрокиНавигационныхСсылок/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ВводСтрокиНавигационныхСсылок/Ext/Form.xml
@@ -26,6 +26,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Сommand panel оptional</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Valfri kommandopanel</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -35,6 +39,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Сommand panel оptional</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Valfri kommandopanel</v8:content>
 				</v8:item>
 			</ToolTip>
 			<HorizontalLocation>Right</HorizontalLocation>
@@ -70,6 +78,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>String navigation links</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Navigeringslänkar (sträng)</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -91,6 +103,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>OK</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>OK</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -100,6 +116,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Сlose window ok</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng fönster OK</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СloseWindowOk</Action>
@@ -114,6 +134,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Correct line</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Korrigera rad</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -123,6 +147,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Сorrect line</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Korrigera rad</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СorrectLine</Action>
@@ -137,6 +165,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Cancel</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avbryt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -146,6 +178,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Сlose window cancel</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng fönster avbryt</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СloseWindowCancel</Action>

--- a/VanessaAutomation/Forms/ВыборИзвестногоШага/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ВыборИзвестногоШага/Ext/Form.xml
@@ -213,6 +213,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Search</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sök</v8:content>
+						</v8:item>
 					</ToolTip>
 					<ClearButton>true</ClearButton>
 					<InputHint>
@@ -223,6 +227,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Enter a search text or a phrase part</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ange en söktext eller en del av en fras</v8:content>
 						</v8:item>
 					</InputHint>
 					<ContextMenu name="НайтиШагиКонтекстноеМеню" id="50"/>
@@ -248,6 +256,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Visible steps setting group</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Inställningsgrupp för synliga steg</v8:content>
 				</v8:item>
 			</Title>
 			<Group>Horizontal</Group>
@@ -276,6 +288,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Show steps in Russian</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa steg på ryska</v8:content>
 						</v8:item>
 					</ToolTip>
 					<CheckBoxType>Auto</CheckBoxType>
@@ -312,6 +328,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Group tree steps</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gruppera trädsteg</v8:content>
+				</v8:item>
 			</Title>
 			<Group>Vertical</Group>
 			<Representation>None</Representation>
@@ -327,6 +347,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Group tree with description</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Gruppträd med beskrivning</v8:content>
 						</v8:item>
 					</Title>
 					<Group>Horizontal</Group>
@@ -392,6 +416,10 @@
 											<v8:lang>ro</v8:lang>
 											<v8:content>Descriere pas</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Stegbeskrivning</v8:content>
+										</v8:item>
 									</Title>
 									<Group>Horizontal</Group>
 									<ExtendedTooltip name="ДеревоШаговГруппаРасширеннаяПодсказка" id="75"/>
@@ -412,6 +440,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Step tree group step type and test view</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Stegträd gruppstegstyp och testvy</v8:content>
 												</v8:item>
 											</Title>
 											<Group>InCell</Group>
@@ -456,6 +488,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Additionally</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Ytterligare</v8:content>
+								</v8:item>
 							</Title>
 							<Group>Vertical</Group>
 							<ExtendedTooltip name="ГруппаОписанияРасширеннаяПодсказка" id="117"/>
@@ -471,6 +507,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>File</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Fil</v8:content>
 										</v8:item>
 									</Title>
 									<AutoMaxWidth>false</AutoMaxWidth>
@@ -500,6 +540,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Description original</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Beskrivning original</v8:content>
+										</v8:item>
 									</ToolTip>
 									<AutoMaxWidth>false</AutoMaxWidth>
 									<MultiLine>true</MultiLine>
@@ -519,6 +563,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Description</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Beskrivning</v8:content>
+										</v8:item>
 									</ToolTip>
 									<AutoMaxWidth>false</AutoMaxWidth>
 									<MultiLine>true</MultiLine>
@@ -536,6 +584,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Description</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Beskrivning</v8:content>
 										</v8:item>
 									</ToolTip>
 									<ContextMenu name="MarkdownViewerКонтекстноеМеню" id="132"/>
@@ -568,6 +620,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Steps tree</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegträd</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1158,6 +1214,10 @@
 							<v8:lang>ro</v8:lang>
 							<v8:content>Limba</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Språk</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1471,6 +1531,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Indent</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Indrag</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1491,6 +1555,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Known step definition table</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Tabell för kända stegdefinitioner</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1606,6 +1674,10 @@
 							<v8:lang>ro</v8:lang>
 							<v8:content>Id</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>ID</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1628,6 +1700,10 @@
 						<v8:item>
 							<v8:lang>vi</v8:lang>
 							<v8:content>Dòng thủ tục thực tế</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Verklig procedursträng</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1652,6 +1728,10 @@
 							<v8:lang>ro</v8:lang>
 							<v8:content>Parametri</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inställningar</v8:content>
+						</v8:item>
 					</Title>
 					<Type/>
 				</Column>
@@ -1664,6 +1744,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>String to search</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sträng att söka</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1683,6 +1767,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Test view</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Testvy</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1707,6 +1795,10 @@
 							<v8:lang>ro</v8:lang>
 							<v8:content>Tranzacția</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Transaktion</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1729,6 +1821,10 @@
 						<v8:item>
 							<v8:lang>ro</v8:lang>
 							<v8:content>Descriere pas</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegbeskrivning</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1753,6 +1849,10 @@
 							<v8:lang>ro</v8:lang>
 							<v8:content>Tipul pas</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegstyp</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1772,6 +1872,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>File version</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Filversion</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:dateTime</v8:Type>
@@ -1789,6 +1893,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>The string was processed</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Strängen har bearbetats</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1906,6 +2014,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Steps tree filter</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegträdsfilter</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2025,6 +2137,10 @@
 					<v8:lang>vi</v8:lang>
 					<v8:content>Thư mục công cụ</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Verktygskatalog</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -2044,6 +2160,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Translation</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Översättning</v8:content>
+				</v8:item>
 			</Title>
 			<Type/>
 		</Attribute>
@@ -2056,6 +2176,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Binary translation file data</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Binär översättningsfildata</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2075,6 +2199,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Translation table cache</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Översättningstabellcache</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2098,6 +2226,10 @@
 				<v8:item>
 					<v8:lang>ro</v8:lang>
 					<v8:content>Este LINUX</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Detta är Linux</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2205,6 +2337,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Show outdated steps</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa föråldrade steg</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -2219,6 +2355,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Parameter snippet</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Parameterutdrag</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2239,6 +2379,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Use markdown viewer</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Använd Markdown-visare</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -2253,6 +2397,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Description (Markdown)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Beskrivning (Markdown)</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2715,6 +2863,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Upload steps to JSON</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Exportera steg till JSON</v8:content>
+				</v8:item>
 			</ToolTip>
 			<Action>ВыгрузитьШагиВJSON</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -2728,6 +2880,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find steps</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hitta steg</v8:content>
 				</v8:item>
 			</Title>
 			<Picture>
@@ -2747,6 +2903,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Close</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2756,6 +2916,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close known steps form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formuläret för kända steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗакрытьФорму</Action>

--- a/VanessaAutomation/Forms/ГенераторДымовыхТестов/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ГенераторДымовыхТестов/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Smoke tests</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Röktest</v8:content>
+		</v8:item>
 	</Title>
 	<AutoSaveDataInSettings>Use</AutoSaveDataInSettings>
 	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1">
@@ -46,6 +50,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Basic Settings</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Grundinställningar</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="СтраницаОсновноеРасширеннаяПодсказка" id="22"/>
 					<ChildItems>
@@ -58,6 +66,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group two columns</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp två kolumner</v8:content>
 								</v8:item>
 							</Title>
 							<Representation>None</Representation>
@@ -73,6 +85,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Left column group</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Vänster kolumngrupp</v8:content>
 										</v8:item>
 									</Title>
 									<Group>Vertical</Group>
@@ -90,6 +106,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Group language steps</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Grupp stegspråk</v8:content>
+												</v8:item>
 											</Title>
 											<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 											<Representation>None</Representation>
@@ -104,6 +124,10 @@
 														<v8:lang>en</v8:lang>
 														<v8:content>The language in which feature file scripts will be generated.</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Språket som feature-filernas skript kommer att genereras på.</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 											<ChildItems>
@@ -117,6 +141,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Language of steps</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Stegspråk</v8:content>
 														</v8:item>
 													</Title>
 													<RadioButtonType>Tumbler</RadioButtonType>
@@ -134,6 +162,10 @@
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Russian</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Ryska</v8:content>
+																	</v8:item>
 																</Presentation>
 																<Value xsi:type="xs:string">ru</Value>
 															</xr:Value>
@@ -150,6 +182,10 @@
 																	<v8:item>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>English</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Engelska</v8:content>
 																	</v8:item>
 																</Presentation>
 																<Value xsi:type="xs:string">en</Value>
@@ -178,6 +214,10 @@
 													<v8:item>
 														<v8:lang>en</v8:lang>
 														<v8:content>The directory where the final feature files will be written.</v8:content>
+													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Katalogen dit de slutgiltiga feature-filerna skrivs.</v8:content>
 													</v8:item>
 												</Title>
 											</ExtendedTooltip>
@@ -213,6 +253,14 @@ Document1
 Document2.ObjectForm
 Document3.ListForm</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Katalogen där textfiler med undantagsobjekt lagras. För varje typ av metadataobjekt eller händelse måste det finnas en separat fil ("Kataloger", "Dokument" osv.).
+Exempel:
+Document1
+Document2.ObjectForm
+Document3.ListForm</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 											<Events>
@@ -238,6 +286,10 @@ Document3.ListForm</v8:content>
 														<v8:lang>en</v8:lang>
 														<v8:content>Path to the script configuration file (the configuration file can be created on the "Batch generation of feature files" tab in the "Smoke Test Generator" window).</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Sökväg till skriptkonfigurationsfilen (konfigurationsfilen kan skapas på fliken "Batchgenerering av feature-filer" i fönstret "Röktestgenerator").</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 											<Events>
@@ -256,6 +308,10 @@ Document3.ListForm</v8:content>
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Right column group</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Höger kolumngrupp</v8:content>
 										</v8:item>
 									</Title>
 									<Group>Vertical</Group>
@@ -279,6 +335,10 @@ Document3.ListForm</v8:content>
 														<v8:lang>en</v8:lang>
 														<v8:content>If set, feature files in the output files directory will be deleted before tests are generated.</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Om detta är aktiverat raderas feature-filer i utdatakatalogen innan testerna genereras.</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 										</CheckBoxField>
@@ -298,6 +358,10 @@ Document3.ListForm</v8:content>
 														<v8:lang>en</v8:lang>
 														<v8:content>When this flag is enabled, only objects for which there is at least one element not marked for deletion in the current infobase will participate in the generation of feature files of extended actions.</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>När denna flagga är aktiverad deltar endast objekt för vilka det finns minst ett element som inte är markerat för radering i den aktuella informationsbasen i genereringen av feature-filer för utökade åtgärder.</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 										</CheckBoxField>
@@ -316,6 +380,10 @@ Document3.ListForm</v8:content>
 													<v8:item>
 														<v8:lang>en</v8:lang>
 														<v8:content>When this flag is enabled, only objects changed relative to the provider configuration will participate in the generation of feature files. To build a report on comparing configurations, the current infobase &lt;b&gt;configurator&lt;/&gt; will be launched with the &lt;b&gt;current user&lt;/&gt; and an &lt;b&gt;empty password&lt;/&gt;.</v8:content>
+													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>När denna flagga är aktiverad deltar endast objekt som ändrats i förhållande till leverantörskonfigurationen i genereringen av feature-filer. För att bygga en rapport om konfigurationsjämförelse startas den aktuella informationsbasens &lt;b&gt;konfigurator&lt;/&gt; med den &lt;b&gt;aktuella användaren&lt;/&gt; och ett &lt;b&gt;tomt lösenord&lt;/&gt;.</v8:content>
 													</v8:item>
 												</Title>
 											</ExtendedTooltip>
@@ -338,6 +406,10 @@ Document3.ListForm</v8:content>
 														<v8:lang>en</v8:lang>
 														<v8:content>The name of the vendor configuration to compare configurations with.</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Namnet på leverantörskonfigurationen att jämföra konfigurationer med.</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 										</InputField>
@@ -356,6 +428,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Batch generation of feature files</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Batchgenerering av feature-filer</v8:content>
 						</v8:item>
 					</Title>
 					<ExtendedTooltip name="СтраницаФомированияСценариевФичаФайламиРасширеннаяПодсказка" id="24"/>
@@ -448,6 +524,10 @@ Document3.ListForm</v8:content>
 													<v8:lang>en</v8:lang>
 													<v8:content>Presentation</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Presentation</v8:content>
+												</v8:item>
 											</Title>
 											<EditMode>EnterOnInput</EditMode>
 											<ContextMenu name="ТаблицаНастроекПредставлениеОбъектаМетаданныхКонтекстноеМеню" id="88"/>
@@ -470,6 +550,10 @@ Document3.ListForm</v8:content>
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Basic actions</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Grundläggande åtgärder</v8:content>
 										</v8:item>
 									</Title>
 									<Group>Horizontal</Group>
@@ -501,6 +585,10 @@ Document3.ListForm</v8:content>
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Advanced Actions</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Utökade åtgärder</v8:content>
 										</v8:item>
 									</Title>
 									<Group>Horizontal</Group>
@@ -549,6 +637,10 @@ Document3.ListForm</v8:content>
 									<v8:lang>en</v8:lang>
 									<v8:content>Document Selection Settings page</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Sida för dokumenturvalsinställningar</v8:content>
+								</v8:item>
 							</Title>
 							<ToolTip>
 								<v8:item>
@@ -558,6 +650,10 @@ Document3.ListForm</v8:content>
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Document Selection Settings page</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Sida för dokumenturvalsinställningar</v8:content>
 								</v8:item>
 							</ToolTip>
 							<ShowTitle>false</ShowTitle>
@@ -573,6 +669,10 @@ Document3.ListForm</v8:content>
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>The starting date for the selection of documents</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Startdatumet för urval av dokument</v8:content>
 										</v8:item>
 									</Title>
 									<ContextMenu name="ДымовыеТестыНачальнаяДатаДляПодбораДокументовКонтекстноеМеню" id="256"/>
@@ -594,6 +694,10 @@ Document3.ListForm</v8:content>
 												<v8:lang>уз</v8:lang>
 												<v8:content>Сана ўрнатилганда, ундан тутун синовлари учун ҳужжатларни танлаш амалга оширилади , яъни ҳужжат санаси &gt;&gt;= ҳужжатларни танлашнинг бошланиш санаси</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Vid inställning av datumet görs urvalet av dokument för röktest från det, det vill säga DokumentDatum &gt;&gt;= Startdatumet för urval av dokument</v8:content>
+											</v8:item>
 										</Title>
 									</ExtendedTooltip>
 									<Events>
@@ -610,6 +714,10 @@ Document3.ListForm</v8:content>
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Sort in descending order</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Sortera i fallande ordning</v8:content>
 										</v8:item>
 									</Title>
 									<CheckBoxType>Auto</CheckBoxType>
@@ -631,6 +739,10 @@ Document3.ListForm</v8:content>
 											<v8:item>
 												<v8:lang>уз</v8:lang>
 												<v8:content>Байроқ ўрнатилганда рўйхатдаги охирги ҳужжатлар танланади.</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>När flaggan är aktiverad väljs de senaste dokumenten från listan</v8:content>
 											</v8:item>
 										</Title>
 									</ExtendedTooltip>
@@ -657,6 +769,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generating scenarios from metadata</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Genererar scenarier från metadata</v8:content>
 						</v8:item>
 					</Title>
 					<Group>AlwaysHorizontal</Group>
@@ -686,6 +802,10 @@ Document3.ListForm</v8:content>
 												<v8:lang>ru</v8:lang>
 												<v8:content>Каталог файлов исключений</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Katalogen där textfiler med undantagsobjekt lagras. För varje typ av metadataobjekt eller händelse måste det finnas en separat fil ("Kataloger", "Dokument" osv.).</v8:content>
+											</v8:item>
 										</Title>
 									</ExtendedTooltip>
 									<Events>
@@ -704,6 +824,10 @@ Document3.ListForm</v8:content>
 											<v8:lang>en</v8:lang>
 											<v8:content>Only entered objects (Directories, Documents and others)</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Endast inmatade objekt (Kataloger, Dokument och andra)</v8:content>
+										</v8:item>
 									</Title>
 									<TitleLocation>Right</TitleLocation>
 									<ToolTipRepresentation>None</ToolTipRepresentation>
@@ -718,6 +842,10 @@ Document3.ListForm</v8:content>
 											<v8:item>
 												<v8:lang>ru</v8:lang>
 												<v8:content>Только введенные объекты (Справочники, Документы, ПВХ)</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>När denna flagga är aktiverad deltar endast objekt för vilka det finns minst ett element som inte är markerat för radering i den aktuella informationsbasen i genereringen av feature-filer för utökade åtgärder.</v8:content>
 											</v8:item>
 										</Title>
 									</ExtendedTooltip>
@@ -759,6 +887,10 @@ Document3.ListForm</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Additionally, the exclusion file directory and "Only entered objects" from "Basic settings" are used</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Dessutom används katalogen för undantagsfiler och "Endast inmatade objekt" från "Grundinställningar"</v8:content>
 														</v8:item>
 													</Title>
 												</ExtendedTooltip>
@@ -830,6 +962,10 @@ Document3.ListForm</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Presentation</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Presentation</v8:content>
+														</v8:item>
 													</Title>
 													<EditMode>EnterOnInput</EditMode>
 													<ContextMenu name="ДеревоМетаданныхПредставлениеКонтекстноеМеню" id="157"/>
@@ -879,6 +1015,10 @@ Document3.ListForm</v8:content>
 													<v8:lang>en</v8:lang>
 													<v8:content>Basic actions</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Grundläggande åtgärder</v8:content>
+												</v8:item>
 											</Title>
 											<HorizontalStretch>false</HorizontalStretch>
 											<Group>Horizontal</Group>
@@ -916,6 +1056,10 @@ Document3.ListForm</v8:content>
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Advanced Actions</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Utökade åtgärder</v8:content>
 												</v8:item>
 											</Title>
 											<HorizontalStretch>false</HorizontalStretch>
@@ -1015,6 +1159,10 @@ Document3.ListForm</v8:content>
 											<v8:lang>en</v8:lang>
 											<v8:content>Catalog feature files</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Katalog feature-filer</v8:content>
+										</v8:item>
 									</Title>
 									<TitleLocation>Top</TitleLocation>
 									<ToolTipRepresentation>None</ToolTipRepresentation>
@@ -1031,6 +1179,10 @@ Document3.ListForm</v8:content>
 											<v8:item>
 												<v8:lang>en</v8:lang>
 												<v8:content>The directory where the final feature files will be written.</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Katalogen dit de slutgiltiga feature-filerna skrivs.</v8:content>
 											</v8:item>
 										</Title>
 									</ExtendedTooltip>
@@ -1153,6 +1305,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Exception files directory</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Katalog undantagsfiler</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -1176,6 +1332,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Output directory</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Utdatakatalog</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -1195,6 +1355,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Vendor Configuration Name</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Leverantörskonfigurationens namn</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1216,6 +1380,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Only changed relative to vendor configuration</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Endast ändrade i förhållande till leverantörskonfigurationen</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1232,6 +1400,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Settings table</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Inställningstabell</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -1246,6 +1418,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Open the list form</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Öppna listformuläret</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1262,6 +1438,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Open the object form</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Öppna objektformuläret</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1276,6 +1456,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Metadata Object</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Metadataobjekt</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1296,6 +1480,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Save (Post) an existing</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Spara (bokför) ett befintligt</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1310,6 +1498,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Copying and save (posting) a new</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kopiera och spara (bokföra) ett nytt</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1326,6 +1518,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1340,6 +1536,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Print</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skriv ut</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1356,6 +1556,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Picture</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bild</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>v8ui:Picture</v8:Type>
@@ -1370,6 +1574,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Presentation of a metadata object</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Presentation av metadataobjekt</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1389,6 +1597,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Priority</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Prioritet</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1412,6 +1624,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Only entered objects for advanced actions</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Endast inmatade objekt för utökade åtgärder</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1427,6 +1643,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Language of steps</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegspråk</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1448,6 +1668,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Message text consistency</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Meddelandetextöverensstämmelse</v8:content>
+				</v8:item>
 			</Title>
 			<Type/>
 		</Attribute>
@@ -1460,6 +1684,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Path to script settings file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sökväg till skriptinställningsfil</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1486,6 +1714,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Clear output directory</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rensa utdatakatalog</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1500,6 +1732,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Shut down the system</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng av systemet</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1516,6 +1752,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Metadata tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Metadataträd</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTree</v8:Type>
@@ -1529,6 +1769,10 @@ Document3.ListForm</v8:content>
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Presentation</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Presentation</v8:content>
 						</v8:item>
 					</Title>
@@ -1550,6 +1794,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Data</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Data</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1568,6 +1816,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Types of props</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Typer av egenskaper</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1588,6 +1840,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Standard props</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Standardegenskaper</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1602,6 +1858,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Note</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Anteckning</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1634,6 +1894,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Name length</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Namnlängd</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:decimal</v8:Type>
@@ -1654,6 +1918,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Open the list form</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Öppna listformuläret</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1668,6 +1936,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Open the object form</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Öppna objektformuläret</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1684,6 +1956,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Save (Post) an existing</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Spara (bokför) ett befintligt</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1698,6 +1974,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Copying and save (posting) a new</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kopiera och spara (bokföra) ett nytt</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1714,6 +1994,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1729,6 +2013,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Print</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skriv ut</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1743,6 +2031,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Metadata object type</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Metadataobjekttyp</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1762,6 +2054,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Level tree</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Trädnivå</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1783,6 +2079,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Records here</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Poster här</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -1797,6 +2097,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Priority</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Prioritet</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1820,6 +2124,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Picture props</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bildegenskaper</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8ui:Picture</v8:Type>
@@ -1834,6 +2142,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Picture table</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bildtabell</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1850,6 +2162,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Script code to embed</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skriptkod att bädda in</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type xmlns:d5p1="http://v8.1c.ru/8.1/data/txtedt">d5p1:TextDocument</v8:Type>
@@ -1865,6 +2181,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Exceptions table</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Undantagstabell</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -1879,6 +2199,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Metadata object type</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Metadataobjekttyp</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1898,6 +2222,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Metadata object exception</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Metadataobjektundantag</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1920,6 +2248,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Table script code to embed</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Tabellskriptkod att bädda in</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -1934,6 +2266,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Script code to embed</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skriptkod att bädda in</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1954,6 +2290,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Title script code to embed</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Rubrikskriptkod att bädda in</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1972,6 +2312,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Path to feature file</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökväg till feature-fil</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1992,6 +2336,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Name feature file for update</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Namn på feature-fil för uppdatering</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -2011,6 +2359,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Picture</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bild</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>v8ui:Picture</v8:Type>
@@ -2026,6 +2378,10 @@ Document3.ListForm</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Feature file updated</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Feature-fil uppdaterad</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -2040,6 +2396,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Type object of metadata</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Typ av metadataobjekt</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -2059,6 +2419,10 @@ Document3.ListForm</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Type test</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Testtyp</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -2081,6 +2445,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>List of feature files</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lista över feature-filer</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueListType</v8:Type>
@@ -2096,6 +2464,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show the full text of the 1C script code</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa den fullständiga texten för 1C-skriptkoden</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -2110,6 +2482,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Script variant</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skriptvariant</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2541,6 +2917,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate files</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera filer</v8:content>
+				</v8:item>
 			</Title>
 			<Action>СформироватьФайлы</Action>
 		</Command>
@@ -2553,6 +2933,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save script settings to a file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara skriptinställningar till en fil</v8:content>
 				</v8:item>
 			</Title>
 			<Action>СохранитьНастройкиСценариевВФайл</Action>
@@ -2567,6 +2951,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download script settings from a file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner skriptinställningar från en fil</v8:content>
+				</v8:item>
 			</Title>
 			<Action>ЗагрузитьНастройкиСценариевИзФайла</Action>
 		</Command>
@@ -2579,6 +2967,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Default</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Standard</v8:content>
 				</v8:item>
 			</Title>
 			<Action>НастройкиСценариевПоУмолчанию</Action>
@@ -2593,6 +2985,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2602,6 +2998,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formulär</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗакрытьФорму</Action>
@@ -2616,6 +3016,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Remove all flags</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta bort alla flaggor</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2625,6 +3029,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Remove all flags</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta bort alla flaggor</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>НастрокиСценариевСнятьВсе</Action>
@@ -2639,6 +3047,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Update metadata structure</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera metadatastruktur</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2648,6 +3060,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>ru</v8:lang>
 					<v8:content>Обновить структуру метаданных</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera metadatastruktur</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -2667,6 +3083,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate scenarios from metadata</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera scenarier från metadata</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2676,6 +3096,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate scenarios from metadata</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera scenarier från metadata</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -2695,6 +3119,10 @@ Document3.ListForm</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Create/update feature files</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skapa/uppdatera feature-filer</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2704,6 +3132,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Create/update feature files</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skapa/uppdatera feature-filer</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -2722,6 +3154,10 @@ Document3.ListForm</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Prepare data</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Förbered data</v8:content>
 				</v8:item>
 			</Title>
 			<Action>ПодготовкаДанных</Action>

--- a/VanessaAutomation/Forms/ГенераторТестов/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ГенераторТестов/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Smoke tests</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Röktest</v8:content>
+		</v8:item>
 	</Title>
 	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1">
 		<ChildItems>
@@ -27,6 +31,10 @@
 					<v8:item>
 						<v8:lang>en</v8:lang>
 						<v8:content>Set up tests...</v8:content>
+					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Ställ in tester...</v8:content>
 					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ФормаГруппаТестыРасширеннаяПодсказка" id="67"/>
@@ -61,6 +69,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Form default group</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Formulärets standardgrupp</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ФормаГруппаПоУмолчаниюРасширеннаяПодсказка" id="91"/>
 						<ChildItems>
@@ -82,6 +94,10 @@
 					<v8:item>
 						<v8:lang>en</v8:lang>
 						<v8:content>Form group settings</v8:content>
+					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Formulärets gruppinställningar</v8:content>
 					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ФормаГруппаНастройкиРасширеннаяПодсказка" id="111"/>
@@ -116,6 +132,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Pages</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sidor</v8:content>
 				</v8:item>
 			</Title>
 			<ExtendedTooltip name="ГруппаСтраницыРасширеннаяПодсказка" id="100"/>
@@ -226,6 +246,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Metadata object tree</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Metadataobjektträd</v8:content>
+								</v8:item>
 							</Title>
 							<ContextMenu name="ДеревоОбъектовМетаданныхКонтекстноеМеню" id="3">
 								<Autofill>false</Autofill>
@@ -259,6 +283,10 @@
 											<v8:item>
 												<v8:lang>en</v8:lang>
 												<v8:content>Object tree context menu default group</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Objektträdets snabbmenystandardgrupp</v8:content>
 											</v8:item>
 										</Title>
 										<ExtendedTooltip name="ДеревоОбъектовКонтекстноеМенюГруппаПоУмолчаниюРасширеннаяПодсказка" id="79"/>
@@ -311,6 +339,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Object tree group 1</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Objektträdsgrupp 1</v8:content>
+										</v8:item>
 									</Title>
 									<Group>InCell</Group>
 									<ExtendedTooltip name="ДеревоОбъектовГруппа1РасширеннаяПодсказка" id="33"/>
@@ -358,6 +390,10 @@
 											<v8:lang>vi</v8:lang>
 											<v8:content>Kịch bản</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Scenarier</v8:content>
+										</v8:item>
 									</Title>
 									<Group>Horizontal</Group>
 									<ShowInHeader>true</ShowInHeader>
@@ -373,6 +409,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Open an object form</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Öppna ett objektformulär</v8:content>
 												</v8:item>
 											</ToolTip>
 											<ThreeState>true</ThreeState>
@@ -392,6 +432,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Save a new object</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Spara ett nytt objekt</v8:content>
 												</v8:item>
 											</ToolTip>
 											<ThreeState>true</ThreeState>
@@ -420,6 +464,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Generate</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Generera</v8:content>
 												</v8:item>
 											</ToolTip>
 											<ThreeState>true</ThreeState>
@@ -557,6 +605,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Metadata object tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Metadataobjektträd</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTree</v8:Type>
@@ -570,6 +622,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Presentation</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Presentation</v8:content>
 						</v8:item>
 					</Title>
@@ -600,6 +656,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Picture</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bild</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>v8ui:Picture</v8:Type>
@@ -629,6 +689,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Mark</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Markering</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:decimal</v8:Type>
@@ -648,6 +712,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Open form</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Öppna formulär</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -669,6 +737,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Generate</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Generera</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:decimal</v8:Type>
@@ -689,6 +761,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Save new object</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Spara nytt objekt</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:decimal</v8:Type>
@@ -708,6 +784,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Save existing</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Spara befintligt</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -746,6 +826,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Generated scenario</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Genererat scenario</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -765,6 +849,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Correspondence of message texts</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Överensstämmelse av meddelandetexter</v8:content>
+				</v8:item>
 			</Title>
 			<Type/>
 		</Attribute>
@@ -780,6 +868,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate scenarios</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera scenarier</v8:content>
+				</v8:item>
 			</Title>
 			<Action>СформироватьСценарии</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -793,6 +885,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna formulär</v8:content>
 				</v8:item>
 			</Title>
 			<Action>УстановитьОткрытиеФормы</Action>
@@ -808,6 +904,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Save new object</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara nytt objekt</v8:content>
+				</v8:item>
 			</Title>
 			<Action>УстановитьЗаписьНового</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -821,6 +921,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save existing object</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara befintligt objekt</v8:content>
 				</v8:item>
 			</Title>
 			<Action>УстановитьЗаписьСуществующего</Action>
@@ -836,6 +940,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera</v8:content>
+				</v8:item>
 			</Title>
 			<Action>УстановитьВводНаОсновании</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -849,6 +957,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>By default</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Som standard</v8:content>
 				</v8:item>
 			</Title>
 			<Picture>
@@ -868,6 +980,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Prepare scenarios</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Förbered scenarier</v8:content>
+				</v8:item>
 			</Title>
 			<Action>ПодготовитьСценарииКВыполнению</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -881,6 +997,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Upload settings...</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Exportera inställningar...</v8:content>
 				</v8:item>
 			</Title>
 			<Picture>
@@ -899,6 +1019,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load settings...</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Importera inställningar...</v8:content>
 				</v8:item>
 			</Title>
 			<Action>ЗагрузитьНастройки</Action>

--- a/VanessaAutomation/Forms/ДеталиОшибки/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ДеталиОшибки/Ext/Form.xml
@@ -128,6 +128,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Cell text only</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Endast celltext</v8:content>
+				</v8:item>
 			</Title>
 			<TitleLocation>Right</TitleLocation>
 			<CheckBoxType>Auto</CheckBoxType>
@@ -144,6 +148,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Compare using *</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Jämför med *</v8:content>
 				</v8:item>
 			</Title>
 			<TitleLocation>Right</TitleLocation>
@@ -163,6 +171,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Detailed error information</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Detaljerad felinformation</v8:content>
 				</v8:item>
 			</ToolTip>
 			<AutoMaxWidth>false</AutoMaxWidth>
@@ -188,6 +200,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Error text</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Feltext</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -207,6 +223,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Table reference</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Tabellreferens</v8:content>
+				</v8:item>
 			</Title>
 			<Type/>
 		</Attribute>
@@ -219,6 +239,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Table current value</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Tabellens aktuella värde</v8:content>
 				</v8:item>
 			</Title>
 			<Type/>
@@ -236,6 +260,10 @@
 				<v8:item>
 					<v8:lang>vi</v8:lang>
 					<v8:content>Thư mục công cụ</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Verktygskatalog</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -350,6 +378,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Compare using *</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Jämför med *</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -364,6 +396,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Tree row number</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Trädradnummer</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -563,6 +599,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Find in steps tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök i stegträdet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -572,6 +612,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find in steps tree</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök i stegträdet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПерейтиКСтрокеДереваСОшибкой</Action>
@@ -586,6 +630,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Update value</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera värde</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -595,6 +643,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Update value</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera värde</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>АктуализироватьЗначение</Action>

--- a/VanessaAutomation/Forms/ИсследовательФормы/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ИсследовательФормы/Ext/Form.xml
@@ -193,6 +193,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Show/hide columns</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Visa/dölj kolumner</v8:content>
+					</v8:item>
 				</ToolTip>
 				<Picture>
 					<xr:Ref>StdPicture.NestedTable</xr:Ref>
@@ -741,6 +745,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Group of flags</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Grupp av flaggor</v8:content>
+				</v8:item>
 			</Title>
 			<Representation>None</Representation>
 			<ShowTitle>false</ShowTitle>
@@ -820,6 +828,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Form tree synonym and picture</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Formulärträd synonym och bild</v8:content>
+						</v8:item>
 					</Title>
 					<ToolTip>
 						<v8:item>
@@ -829,6 +841,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Form tree synonym and picture</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Formulärträd synonym och bild</v8:content>
 						</v8:item>
 					</ToolTip>
 					<Group>InCell</Group>
@@ -914,6 +930,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Tree form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Trädformulär</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1025,6 +1045,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Synonym (caption)</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Synonym (rubrik)</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -1043,6 +1067,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Type int</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Typ int</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1158,6 +1186,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>View int</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Vy int</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1547,6 +1579,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Picture</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bild</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>v8ui:Picture</v8:Type>
@@ -1564,6 +1600,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Get the active item from test client</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta det aktiva objektet från testklienten</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1578,6 +1618,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Steps text</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegtext</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1879,6 +1923,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>A line was changed upon changing the current item in the test client</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>En rad ändrades vid byte av aktuellt objekt i testklienten</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1893,6 +1941,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Cache translation table</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Cache för översättningstabell</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1917,6 +1969,10 @@
 					<v8:lang>ro</v8:lang>
 					<v8:content>Limba</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Språk</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -1936,6 +1992,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Build tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bygg träd</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1951,6 +2011,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>The current testclient is a web client</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Den aktuella testklienten är en webbklient</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1965,6 +2029,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Icons of form elements</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ikoner för formulärelement</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1987,6 +2055,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Owner unique identifier</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ägarens unika identifierare</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -2182,6 +2254,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Show/Hide all columns</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj alla kolumner</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2191,6 +2267,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide all columns</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa dölj alla kolumner</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьВсеКолонки</Action>
@@ -2292,6 +2372,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide type</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa dölj typ</v8:content>
+				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьТип</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -2391,6 +2475,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide type</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa dölj typ</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьВид</Action>
@@ -2492,6 +2580,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide availability</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa dölj tillgänglighet</v8:content>
+				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьДоступность</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -2591,6 +2683,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide visibility</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa dölj synlighet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьВидимость</Action>
@@ -2692,6 +2788,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide view-only</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa dölj skrivskyddad</v8:content>
+				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьТолькоПросмотр</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -2706,6 +2806,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Select window</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Välj fönster</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -2715,6 +2819,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Select window</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Välj fönster</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВыбратьОкно</Action>

--- a/VanessaAutomation/Forms/МастерНастройкиИнтерактивнойСправки/Ext/Form.xml
+++ b/VanessaAutomation/Forms/МастерНастройкиИнтерактивнойСправки/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Online Help Customization Wizard</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Guide för anpassning av interaktiv hjälp</v8:content>
+		</v8:item>
 	</Title>
 	<Width>50</Width>
 	<WindowOpeningMode>LockOwnerWindow</WindowOpeningMode>
@@ -40,6 +44,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Setting group</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Inställningsgrupp</v8:content>
+				</v8:item>
 			</Title>
 			<Group>Vertical</Group>
 			<ShowTitle>false</ShowTitle>
@@ -54,6 +62,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Group enable component</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Grupp aktivera komponent</v8:content>
 						</v8:item>
 					</Title>
 					<Group>AlwaysHorizontal</Group>
@@ -90,6 +102,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Disabled use of external component</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Användning av extern komponent inaktiverad</v8:content>
+								</v8:item>
 							</Title>
 							<ContextMenu name="ИспользованиеКомпонентыВыключеноКонтекстноеМеню" id="34"/>
 							<ExtendedTooltip name="ИспользованиеКомпонентыВыключеноРасширеннаяПодсказка" id="35"/>
@@ -103,6 +119,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Enabled use of external component</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Användning av extern komponent aktiverad</v8:content>
 								</v8:item>
 							</Title>
 							<ContextMenu name="ИспользованиеКомпонентыВключеноКонтекстноеМеню" id="9"/>
@@ -124,6 +144,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Cash voice group</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Grupp röstcache</v8:content>
 						</v8:item>
 					</Title>
 					<Group>AlwaysHorizontal</Group>
@@ -160,6 +184,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Voiceover cache not found</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Röstcache hittades inte</v8:content>
+								</v8:item>
 							</Title>
 							<ContextMenu name="КартинкаКешОзвучкиНеНайденКонтекстноеМеню" id="37"/>
 							<ExtendedTooltip name="КартинкаКешОзвучкиНеНайденРасширеннаяПодсказка" id="38"/>
@@ -174,6 +202,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Downloading...</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Laddar ner...</v8:content>
+								</v8:item>
 							</Title>
 							<ContextMenu name="КартинкаКешОзвучкиИдетСкачиваниеКонтекстноеМеню" id="40"/>
 							<ExtendedTooltip name="КартинкаКешОзвучкиИдетСкачиваниеРасширеннаяПодсказка" id="41"/>
@@ -187,6 +219,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Found the voice acting cache</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Röstcache hittad</v8:content>
 								</v8:item>
 							</Title>
 							<ContextMenu name="КартинкаКешОзвучкиНайденКонтекстноеМеню" id="25"/>
@@ -208,6 +244,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Group download lessons</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Grupp ladda ner lektioner</v8:content>
 						</v8:item>
 					</Title>
 					<Group>AlwaysHorizontal</Group>
@@ -244,6 +284,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Lesson files not found</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Lektionsfiler hittades inte</v8:content>
+								</v8:item>
 							</Title>
 							<ContextMenu name="КартинкаСкачатьУрокиНеНайденыКонтекстноеМеню" id="51"/>
 							<ExtendedTooltip name="КартинкаСкачатьУрокиНеНайденыРасширеннаяПодсказка" id="52"/>
@@ -258,6 +302,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Downloading...</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Laddar ner...</v8:content>
+								</v8:item>
 							</Title>
 							<ContextMenu name="КартинкаСкачатьУрокиИдетСкачиваниеКонтекстноеМеню" id="54"/>
 							<ExtendedTooltip name="КартинкаСкачатьУрокиИдетСкачиваниеРасширеннаяПодсказка" id="55"/>
@@ -271,6 +319,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Lessons found</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Lektioner hittade</v8:content>
 								</v8:item>
 							</Title>
 							<ContextMenu name="КартинкаСкачатьУрокиНайденыКонтекстноеМеню" id="57"/>
@@ -303,6 +355,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Checked feature file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kontrollerad feature-fil</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -321,6 +377,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>MDFile Line</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>MDFil-rad</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -341,6 +401,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Download lessons</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner lektioner</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -355,6 +419,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Transition from opening the list of lessons</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Övergång från öppning av lektionslistan</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -373,6 +441,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Enable</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Aktivera</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -382,6 +454,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Enable use of external component</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Aktivera användning av extern komponent</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВключитьИспользованиеВнешнейКомпоненты</Action>
@@ -396,6 +472,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Download</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -405,6 +485,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download voice cache</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner röstcache</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СкачатьКешОзвучки</Action>
@@ -419,6 +503,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Continue</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fortsätt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -428,6 +516,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Continue lesson</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fortsätt lektion</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПродолжитьУрок</Action>
@@ -447,6 +539,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download lessons</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner lektioner</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СкачатьУроки</Action>

--- a/VanessaAutomation/Forms/НастройкаВидимостиКнопокКоманднойПанелиРедактора/Ext/Form.xml
+++ b/VanessaAutomation/Forms/НастройкаВидимостиКнопокКоманднойПанелиРедактора/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Setting the visibility of buttons</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Inställning av knappsynlighet</v8:content>
+		</v8:item>
 	</Title>
 	<Width>80</Width>
 	<Height>40</Height>
@@ -29,6 +33,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Save</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Spara</v8:content>
+					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ФормаКомандаОКРасширеннаяПодсказка" id="4"/>
 			</Button>
@@ -43,6 +51,10 @@
 					<v8:item>
 						<v8:lang>en</v8:lang>
 						<v8:content>Cancel</v8:content>
+					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Avbryt</v8:content>
 					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ФормаКомандаОтменитьРасширеннаяПодсказка" id="6"/>
@@ -98,6 +110,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Button data form</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Knappdata formulär</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueListType</v8:Type>
@@ -115,6 +131,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Main command</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Huvudkommando</v8:content>
+				</v8:item>
 			</Title>
 			<Action>ОсновнаяКоманда</Action>
 		</Command>
@@ -128,6 +148,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>OK</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>OK</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -137,6 +161,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save visibility settings</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara synlighetsinställningar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>КомандаОК</Action>
@@ -151,6 +179,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Cancel</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avbryt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -160,6 +192,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Cancel saving visibility settings</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avbryt sparande av synlighetsinställningar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>КомандаОтменить</Action>
@@ -174,6 +210,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Check all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -183,6 +223,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Check all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>КомандаПометитьВсе</Action>
@@ -197,6 +241,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Uncheck all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avmarkera alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -206,6 +254,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Uncheck all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avmarkera alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>КомандаСнятьВсе</Action>

--- a/VanessaAutomation/Forms/НастройкаРедактора/Ext/Form.xml
+++ b/VanessaAutomation/Forms/НастройкаРедактора/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Editor settings</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Redigeringsinställningar</v8:content>
+		</v8:item>
 	</Title>
 	<WindowOpeningMode>LockOwnerWindow</WindowOpeningMode>
 	<AutoTitle>false</AutoTitle>
@@ -107,6 +111,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>ЧН=0</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>ЧН=0</v8:content>
+						</v8:item>
 					</Format>
 					<EditFormat>
 						<v8:item>
@@ -115,6 +123,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>ЧН=0</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>ЧН=0</v8:content>
 						</v8:item>
 					</EditFormat>
@@ -174,6 +186,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Options</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Alternativ</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTree</v8:Type>
@@ -188,6 +204,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Description</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Beskrivning</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -208,6 +228,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Name</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Namn</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -226,6 +250,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Scheme</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Schema</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -246,6 +274,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Default value</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Standardvärde</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -264,6 +296,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Type</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Typ</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -284,6 +320,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Value</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Värde</v8:content>
+						</v8:item>
 					</Title>
 					<Type/>
 				</Column>
@@ -296,6 +336,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Different</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Avvikande</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -338,6 +382,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Save and close</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara och stäng</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -347,6 +395,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save and close</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara och stäng</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗаписатьИЗакрыть</Action>

--- a/VanessaAutomation/Forms/НастройкиGit/Ext/Form.xml
+++ b/VanessaAutomation/Forms/НастройкиGit/Ext/Form.xml
@@ -25,6 +25,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Close</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Stäng</v8:content>
+					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ФормаЗакрытьРасширеннаяПодсказка" id="26"/>
 			</Button>
@@ -44,6 +48,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Main pages</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Huvudsidor</v8:content>
+				</v8:item>
 			</Title>
 			<ExtendedTooltip name="MainPagesExtendedTooltip" id="28"/>
 			<ChildItems>
@@ -56,6 +64,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Remote</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Fjärrlagringsplats</v8:content>
 						</v8:item>
 					</Title>
 					<ExtendedTooltip name="RemotePageExtendedTooltip" id="30"/>
@@ -129,6 +141,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Signature</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Signatur</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="SignaturePageExtendedTooltip" id="6"/>
 					<ChildItems>
@@ -141,6 +157,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group author</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp författare</v8:content>
 								</v8:item>
 							</Title>
 							<Group>Vertical</Group>
@@ -157,6 +177,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Signature panel</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Signaturpanel</v8:content>
 										</v8:item>
 									</Title>
 									<ExtendedTooltip name="SignaturePanelExtendedTooltip" id="10"/>
@@ -175,6 +199,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Group set signature</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Grupp ange signatur</v8:content>
 												</v8:item>
 											</Title>
 											<Representation>Compact</Representation>
@@ -222,6 +250,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>E-Mail</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>E-post</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -240,6 +272,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Name</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Namn</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -260,6 +296,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Remote list</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fjärrlista</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -274,6 +314,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Name</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Namn</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -292,6 +336,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Url</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Url</v8:content>
 						</v8:item>
 					</Title>
@@ -317,6 +365,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Set committer</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange committer</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -326,6 +378,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Set committer</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange committer</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>SetSignatureCommitter</Action>
@@ -341,6 +397,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Set author</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange författare</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -350,6 +410,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Set author</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange författare</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>SetSignatureAuthor</Action>
@@ -365,6 +429,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Get default</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta standard</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -374,6 +442,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get default</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta standard</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>GetDefaultSignature</Action>

--- a/VanessaAutomation/Forms/НастройкиРаботыСБраузером/Ext/Form.xml
+++ b/VanessaAutomation/Forms/НастройкиРаботыСБраузером/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Browser settings</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Webbläsarinställningar</v8:content>
+		</v8:item>
 	</Title>
 	<AutoSaveDataInSettings>Use</AutoSaveDataInSettings>
 	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1"/>
@@ -28,6 +32,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Pages</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sidor</v8:content>
+				</v8:item>
 			</Title>
 			<PagesRepresentation>TabsOnLeftHorizontal</PagesRepresentation>
 			<ExtendedTooltip name="СтраницыРасширеннаяПодсказка" id="27"/>
@@ -42,6 +50,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Address, Browser</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Adress, Webbläsare</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="СтраницаАдресРасширеннаяПодсказка" id="29"/>
 					<ChildItems>
@@ -55,6 +67,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Web socket commands</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>WebSocket-kommandon</v8:content>
+								</v8:item>
 							</Title>
 							<ExtendedTooltip name="КомандыWebSocketРасширеннаяПодсказка" id="2"/>
 							<ChildItems>
@@ -67,6 +83,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Browser startup group</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Grupp webbläsarstart</v8:content>
 										</v8:item>
 									</Title>
 									<Representation>Compact</Representation>
@@ -109,6 +129,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Drawing</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Ritning</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="СтраницаРисованиеРасширеннаяПодсказка" id="31"/>
 					<ChildItems>
@@ -121,6 +145,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Javascript text</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>JavaScript-text</v8:content>
 								</v8:item>
 							</Title>
 							<Group>Vertical</Group>
@@ -136,6 +164,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Javascript group</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>JavaScript-grupp</v8:content>
 										</v8:item>
 									</Title>
 									<Group>AlwaysHorizontal</Group>
@@ -171,6 +203,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group drawing coordinates</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp ritningskoordinater</v8:content>
 								</v8:item>
 							</Title>
 							<Group>AlwaysHorizontal</Group>
@@ -254,6 +290,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Group drawing team</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp ritningskommando</v8:content>
+								</v8:item>
 							</Title>
 							<Representation>None</Representation>
 							<ShowTitle>false</ShowTitle>
@@ -289,6 +329,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>HTML text</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>HTML-text</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="СтраницаHTMLРасширеннаяПодсказка" id="66"/>
 					<ChildItems>
@@ -301,6 +345,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Browser command group</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp webbläsarkommando</v8:content>
 								</v8:item>
 							</Title>
 							<Group>AlwaysHorizontal</Group>
@@ -354,6 +402,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Show element commands for browser</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Visa elementkommandon för webbläsare</v8:content>
+								</v8:item>
 							</Title>
 							<Group>Vertical</Group>
 							<Behavior>PopUp</Behavior>
@@ -371,6 +423,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Commands for the current page field:</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Kommandon för det aktuella sidfältet:</v8:content>
+										</v8:item>
 									</Title>
 									<ContextMenu name="ДекорацияКомандыПоляКонтекстноеМеню" id="110"/>
 									<ExtendedTooltip name="ДекорацияКомандыПоляРасширеннаяПодсказка" id="111"/>
@@ -384,6 +440,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Page element group</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Grupp sidelement</v8:content>
 										</v8:item>
 									</Title>
 									<Group>Vertical</Group>
@@ -490,6 +550,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>URL</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>URL</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -507,6 +571,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>WS</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>WS</v8:content>
 				</v8:item>
 			</Title>
@@ -528,6 +596,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Text JavaScript</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>JavaScript-text</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -547,6 +619,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Screenshot</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skärmbild</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -564,6 +640,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>H</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>H</v8:content>
 				</v8:item>
 			</Title>
@@ -586,6 +666,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>W</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>W</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -606,6 +690,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Figure type</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Figurtyp</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -623,6 +711,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>X</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>X</v8:content>
 				</v8:item>
 			</Title>
@@ -645,6 +737,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Y</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Y</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -665,6 +761,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Caption (text)</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rubrik (text)</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -683,6 +783,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>HTML text</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>HTML-text</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -703,6 +807,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Browser element commands</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Webbläsarelementkommandon</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueListType</v8:Type>
@@ -716,6 +824,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>ID</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>ID</v8:content>
 				</v8:item>
 			</Title>
@@ -737,6 +849,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Name</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Namn</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -755,6 +871,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Class name</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Klassnamn</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -775,6 +895,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Browser command</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Webbläsarkommando</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -794,6 +918,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Step command</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegkommando</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -812,6 +940,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>JSON result</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>JSON-resultat</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -834,6 +966,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Launch browser</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta webbläsare</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -843,6 +979,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Launch browser</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta webbläsare</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗапуститьБраузер</Action>
@@ -858,6 +998,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Open URL</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna URL</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -867,6 +1011,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open URL</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna URL</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ОткрытьURL</Action>
@@ -882,6 +1030,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Execute java sctipt</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör JavaScript</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -891,6 +1043,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Execute java sctipt</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör JavaScript</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -911,6 +1067,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Screenshot of the browser</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skärmbild av webbläsaren</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -920,6 +1080,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Screenshot of the browser</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skärmbild av webbläsaren</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -940,6 +1104,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Show browser element commands</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa webbläsarelementkommandon</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -949,6 +1117,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show browser element commands</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa webbläsarelementkommandon</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьКомандыЭлементаБраузера</Action>
@@ -963,6 +1135,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Copy to clipboard</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kopiera till urklipp</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -972,6 +1148,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Browser element command to clipboard</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Webbläsarelementkommando till urklipp</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -991,6 +1171,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Copy to clipboard</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kopiera till urklipp</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1000,6 +1184,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Browser command to buffer</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Webbläsarkommando till urklipp</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -1019,6 +1207,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Show HTML code</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa HTML-kod</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1028,6 +1220,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show browser element commands</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa webbläsarelementkommandon</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьКодHTML</Action>

--- a/VanessaAutomation/Forms/ОбщегоНазначенияVA/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ОбщегоНазначенияVA/Ext/Form.xml
@@ -21,6 +21,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Synchronous calls not allowed</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Synkrona anrop inte tillåtna</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -35,6 +39,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>File optimization possible</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Filoptimering möjlig</v8:content>
 				</v8:item>
 			</Title>
 			<Type>

--- a/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ПодготовкаИЗагрузкаДанных/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Test data generator</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Testdatagenerator</v8:content>
+		</v8:item>
 	</Title>
 	<AutoSaveDataInSettings>Use</AutoSaveDataInSettings>
 	<SaveDataInSettings>UseList</SaveDataInSettings>
@@ -30,6 +34,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Main settings</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Huvudinställningar</v8:content>
+				</v8:item>
 			</Title>
 			<Behavior>Collapsible</Behavior>
 			<ControlRepresentation>Picture</ControlRepresentation>
@@ -47,6 +55,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Step language</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegspråk</v8:content>
+						</v8:item>
 					</Title>
 					<RadioButtonType>Tumbler</RadioButtonType>
 					<ChoiceList>
@@ -62,6 +74,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>English</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Engelska</v8:content>
 									</v8:item>
 								</Presentation>
 								<Value xsi:type="xs:string">en</Value>
@@ -79,6 +95,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Russian</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Ryska</v8:content>
 									</v8:item>
 								</Presentation>
 								<Value xsi:type="xs:string">ru</Value>
@@ -103,6 +123,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>БЛ=No; БИ=Yes</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>БЛ=Nej; БИ=Ja</v8:content>
+						</v8:item>
 					</EditFormat>
 					<ContextMenu name="UseDataExhangeLoadTrueКонтекстноеМеню" id="156"/>
 					<ExtendedTooltip name="UseDataExhangeLoadTrueРасширеннаяПодсказка" id="157"/>
@@ -118,6 +142,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>If in the object's metadata tree the attribute search attribute is specified and the attribute name is specified, then when generating data, the link will be replaced by the value of this attribute (with service prefixes). When loading data, the object will be searched for by the attribute and its value.</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Om attributet för sökning efter attribut anges i objektets metadataträd och attributnamnet anges, ersätts länken vid generering av data med värdet för detta attribut (med tjänsteprefix). Vid inläsning av data söks objektet efter attribut och dess värde.</v8:content>
+						</v8:item>
 					</ToolTip>
 					<ToolTipRepresentation>Button</ToolTipRepresentation>
 					<CheckBoxType>Tumbler</CheckBoxType>
@@ -129,6 +157,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>БЛ=No; БИ=Yes</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>БЛ=Nej; БИ=Ja</v8:content>
 						</v8:item>
 					</EditFormat>
 					<ContextMenu name="ReplaceRefByAttributeContextMenu" id="169"/>
@@ -149,6 +181,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Upload Storage to File</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda upp lagring till fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -158,6 +194,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Parameters for upload ValueStorage to files</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Parametrar för uppladdning av värdelagring till filer</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Group>AlwaysHorizontal</Group>
@@ -179,6 +219,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>БЛ=No; БИ=Yes</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>БЛ=Nej; БИ=Ja</v8:content>
+						</v8:item>
 					</EditFormat>
 					<ContextMenu name="CreateFileForStorageКонтекстноеМеню" id="178"/>
 					<ExtendedTooltip name="CreateFileForStorageРасширеннаяПодсказка" id="179"/>
@@ -195,6 +239,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Group path</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Gruppsökväg</v8:content>
 						</v8:item>
 					</Title>
 					<HorizontalStretch>true</HorizontalStretch>
@@ -224,6 +272,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>БЛ=No; БИ=Yes</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>БЛ=Nej; БИ=Ja</v8:content>
+								</v8:item>
 							</EditFormat>
 							<ContextMenu name="MakeAbsPathКонтекстноеМеню" id="189"/>
 							<ExtendedTooltip name="MakeAbsPathРасширеннаяПодсказка" id="190"/>
@@ -242,6 +294,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Group pages</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gruppsidor</v8:content>
+				</v8:item>
 			</Title>
 			<ExtendedTooltip name="GroupPagesExtendedTooltip" id="73"/>
 			<ChildItems>
@@ -254,6 +310,10 @@
 						<v8:item>
 							<v8:lang>ru</v8:lang>
 							<v8:content>Отбор по метаданным</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Huvudsida</v8:content>
 						</v8:item>
 					</Title>
 					<ExtendedTooltip name="GroupPageMainExtendedTooltip" id="75"/>
@@ -286,6 +346,10 @@
 																<v8:lang>en</v8:lang>
 																<v8:content>Metadata list group select</v8:content>
 															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Välj metadatalistgrupp</v8:content>
+															</v8:item>
 														</Title>
 														<ToolTip>
 															<v8:item>
@@ -295,6 +359,10 @@
 															<v8:item>
 																<v8:lang>en</v8:lang>
 																<v8:content>Metadata list group select</v8:content>
+															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Välj metadatalistgrupp</v8:content>
 															</v8:item>
 														</ToolTip>
 														<Representation>Compact</Representation>
@@ -322,6 +390,10 @@
 																<v8:lang>en</v8:lang>
 																<v8:content>Metadata list group sort</v8:content>
 															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Sortera metadatalistgrupp</v8:content>
+															</v8:item>
 														</Title>
 														<ToolTip>
 															<v8:item>
@@ -331,6 +403,10 @@
 															<v8:item>
 																<v8:lang>en</v8:lang>
 																<v8:content>Metadata list group sort</v8:content>
+															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Sortera metadatalistgrupp</v8:content>
 															</v8:item>
 														</ToolTip>
 														<Representation>Compact</Representation>
@@ -373,6 +449,10 @@
 															<v8:item>
 																<v8:lang>en</v8:lang>
 																<v8:content>Close</v8:content>
+															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Stäng</v8:content>
 															</v8:item>
 														</Title>
 														<ExtendedTooltip name="MetadataListCloseFormРасширеннаяПодсказка" id="161"/>
@@ -433,6 +513,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Metadata list picture and presentation</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Metadatalista bild och presentation</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -442,6 +526,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Metadata list picture and presentation</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Metadatalista bild och presentation</v8:content>
 														</v8:item>
 													</ToolTip>
 													<Group>InCell</Group>
@@ -554,6 +642,10 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Отбор по ссылкам</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Filtrera efter referenser</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="GroupPageFilterByRefsРасширеннаяПодсказка" id="94"/>
 					<ChildItems>
@@ -577,6 +669,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Group include dependencies</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp inkludera beroenden</v8:content>
+								</v8:item>
 							</Title>
 							<ToolTip>
 								<v8:item>
@@ -586,6 +682,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group include dependencies</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp inkludera beroenden</v8:content>
 								</v8:item>
 							</ToolTip>
 							<Group>AlwaysHorizontal</Group>
@@ -613,6 +713,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Recommended value is not more than 1</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Rekommenderat värde är högst 1</v8:content>
 										</v8:item>
 									</ToolTip>
 									<ContextMenu name="MaxDownstreamDependenciesHierarchyLevelКонтекстноеМеню" id="129"/>
@@ -713,6 +817,10 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Фича</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Feature</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="GroupPageFeatureExtendedTooltip" id="77"/>
 					<ChildItems>
@@ -726,6 +834,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Group feature command</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp feature-kommando</v8:content>
+								</v8:item>
 							</Title>
 							<ToolTip>
 								<v8:item>
@@ -735,6 +847,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group feature command</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp feature-kommando</v8:content>
 								</v8:item>
 							</ToolTip>
 							<Representation>None</Representation>
@@ -776,6 +892,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Metadata type</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Metadatatyp</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueListType</v8:Type>
@@ -792,6 +912,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Metadata list</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Metadatalista</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTree</v8:Type>
@@ -806,6 +930,10 @@
 						<v8:item>
 							<v8:lang>ru</v8:lang>
 							<v8:content>Имя</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Namn</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -826,6 +954,10 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Использовать</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Använd</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -840,6 +972,10 @@
 						<v8:item>
 							<v8:lang>ru</v8:lang>
 							<v8:content>Представление</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Presentation</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -860,6 +996,10 @@
 							<v8:lang>ru</v8:lang>
 							<v8:content>Полное имя</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Fullständigt namn</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -879,6 +1019,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Use search by attribute</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sök efter attribut</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -894,6 +1038,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Search attribute</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sökattribut</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -914,6 +1062,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Рicture</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bild</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>v8ui:Picture</v8:Type>
@@ -928,6 +1080,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Count</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Antal</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -951,6 +1107,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Data list</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Datalista</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -966,6 +1126,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Feature</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Feature</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type xmlns:d5p1="http://v8.1c.ru/8.1/data/txtedt">d5p1:TextDocument</v8:Type>
@@ -976,6 +1140,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Steps language</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegspråk</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -999,6 +1167,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Initialized</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Initierad</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1013,6 +1185,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Include upstream dependencies (references in an object)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Inkludera uppåtgående beroenden (referenser i ett objekt)</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1032,6 +1208,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Include downstream dependencies (object references)</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Inkludera nedåtgående beroenden (objektreferenser)</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1050,6 +1230,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Don't add comments with metadata object names</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg inte till kommentarer med metadataobjektnamn</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1067,6 +1251,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Max hierarchy level</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Max hierarkinivå</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1091,6 +1279,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Data refs</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Datareferenser</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -1109,6 +1301,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Object</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Objekt</v8:content>
+						</v8:item>
 					</Title>
 					<Type/>
 				</Column>
@@ -1121,6 +1317,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Include downstream dependencies</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inkludera nedåtgående beroenden</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1136,6 +1336,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Include upstream dependencies</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inkludera uppåtgående beroenden</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -1154,6 +1358,10 @@
 					<v8:lang>ru</v8:lang>
 					<v8:content>ОбменДанными.Загрузка</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>DataExhange.Load</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1168,6 +1376,10 @@
 				<v8:item>
 					<v8:lang>ru</v8:lang>
 					<v8:content>Заменять ссылку на реквизит</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ersätt referens med attribut</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1187,6 +1399,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Upload</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda upp</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1204,6 +1420,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Path</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sökväg</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1224,6 +1444,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>File type</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Filtyp</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -1247,6 +1471,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Absolute path</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Absolut sökväg</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -1265,6 +1493,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Files to save</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Filer att spara</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueListType</v8:Type>
@@ -1282,6 +1514,10 @@
 					<v8:lang>ru</v8:lang>
 					<v8:content>Сгенерировать фичу</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera feature</v8:content>
+				</v8:item>
 			</Title>
 			<Action>GenerateFeature</Action>
 		</Command>
@@ -1294,6 +1530,10 @@
 				<v8:item>
 					<v8:lang>ru</v8:lang>
 					<v8:content>Выбрать зависимые элементы</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Välj beroende objekt</v8:content>
 				</v8:item>
 			</Title>
 			<Action>SelectDependentItems</Action>
@@ -1308,6 +1548,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate feature</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera feature</v8:content>
+				</v8:item>
 			</Title>
 			<Action>GenerateFeatureForRefs</Action>
 		</Command>
@@ -1320,6 +1564,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Add by link</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg till via länk</v8:content>
 				</v8:item>
 			</Title>
 			<Action>AddObjectByURL</Action>
@@ -1334,6 +1582,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Close form</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formulär</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1343,6 +1595,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close the data preparation and loading form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formuläret för dataförberedelse och inläsning</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>CloseForm</Action>
@@ -1357,6 +1613,10 @@
 					<v8:lang>ru</v8:lang>
 					<v8:content>Заменить ссылки реквизитами</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ersätt referens med attribut</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1366,6 +1626,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Process replace ref by attribute</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bearbeta ersättning av referens med attribut</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ProcessReplaceRefByAttribute</Action>
@@ -1380,6 +1644,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Select all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1389,6 +1657,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Select all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -1407,6 +1679,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Deselect all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avmarkera alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1416,6 +1692,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Deselect all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avmarkera alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -1434,6 +1714,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Update count</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera antal</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1443,6 +1727,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Update metadata count</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera metadataantal</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>UpdateMetadataCount</Action>

--- a/VanessaAutomation/Forms/ПодробнаяИнформацияОШаге/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ПодробнаяИнформацияОШаге/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Step details</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Stegdetaljer</v8:content>
+		</v8:item>
 	</Title>
 	<Width>64</Width>
 	<Height>30</Height>
@@ -94,6 +98,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>File whith step</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fil med steg</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -112,6 +120,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Step description</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegbeskrivning</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -132,6 +144,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Usage example</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Användningsexempel</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -150,6 +166,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Step type</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegtyp</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -170,6 +190,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Procedure name</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Procedurnamn</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -188,6 +212,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Snippet</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Utdrag</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -210,6 +238,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Find in the tree of steps</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök i stegträdet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -219,6 +251,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find in the tree of steps</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök i stegträdet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>НайтиВДеревеШагов</Action>
@@ -233,6 +269,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Close form</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formulär</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -242,6 +282,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formulär</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗакрытьФорму</Action>

--- a/VanessaAutomation/Forms/ПолучениеКоординатПоОбласти/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ПолучениеКоординатПоОбласти/Ext/Form.xml
@@ -9,6 +9,10 @@
 			<v8:lang>en</v8:lang>
 			<v8:content>Getting coordinates by area</v8:content>
 		</v8:item>
+		<v8:item>
+			<v8:lang>sv</v8:lang>
+			<v8:content>Hämta koordinater efter område</v8:content>
+		</v8:item>
 	</Title>
 	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1">
 		<Autofill>false</Autofill>
@@ -37,6 +41,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>The selection process is in progress.</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markeringsprocessen pågår.</v8:content>
 				</v8:item>
 			</Title>
 			<ContextMenu name="ДекорацияИдетПроцессКонтекстноеМеню" id="52"/>
@@ -163,6 +171,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Printscreen</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skärmbild</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -180,6 +192,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>X</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>X</v8:content>
 				</v8:item>
 			</Title>
@@ -202,6 +218,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Y</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Y</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -221,6 +241,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>width</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>bredd</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -242,6 +266,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>height</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>höjd</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -261,6 +289,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Handle to the main window of the current testing client</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Handtag till huvudfönstret för den aktuella testklienten</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -282,6 +314,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Handle to the main VA window</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Handtag till huvudfönstret för VA</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -302,6 +338,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Client test window is active</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Testklientens fönster är aktivt</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -316,6 +356,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Step construction</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegkonstruktion</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -336,6 +380,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Step construction (others)</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegkonstruktion (övriga)</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -354,6 +402,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Step design (others) - text</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegdesign (övriga) - text</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -374,6 +426,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Step construction other table</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stegkonstruktion övrig tabell</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -388,6 +444,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Value</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Värde</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -406,6 +466,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Presentation</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Presentation</v8:content>
 						</v8:item>
 					</Title>
@@ -431,6 +495,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Select area</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Välj område</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -440,6 +508,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Select area</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Välj område</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>МониторингСобытийНачать</Action>
@@ -454,6 +526,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Copy to clipboard</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kopiera till urklipp</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -463,6 +539,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Buffer step design</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Buffra stegdesign</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -482,6 +562,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Copy to clipboard</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kopiera till urklipp</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -491,6 +575,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Copy to clipboard</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kopiera till urklipp</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>

--- a/VanessaAutomation/Forms/РедактированиеТаблицы/Ext/Form.xml
+++ b/VanessaAutomation/Forms/РедактированиеТаблицы/Ext/Form.xml
@@ -44,6 +44,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Table on the form</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Tabell på formuläret</v8:content>
+						</v8:item>
 					</Title>
 					<RowFilter xsi:nil="true"/>
 					<ContextMenu name="ТаблицаНаФормеКонтекстноеМеню" id="2"/>
@@ -92,6 +96,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Column list</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Kolumnlista</v8:content>
+						</v8:item>
 					</Title>
 					<ContextMenu name="СписокКолонокКонтекстноеМеню" id="20"/>
 					<AutoCommandBar name="СписокКолонокКоманднаяПанель" id="21">
@@ -106,6 +114,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>List of mark columns</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Lista över markeringskolumner</v8:content>
 									</v8:item>
 								</Title>
 								<Representation>Compact</Representation>
@@ -143,6 +155,10 @@
 										<v8:lang>en</v8:lang>
 										<v8:content>Column list group shift column</v8:content>
 									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Kolumnlistgrupp flytta kolumn</v8:content>
+									</v8:item>
 								</Title>
 								<Representation>Compact</Representation>
 								<ExtendedTooltip name="СписокКолонокГруппаСдвинутьКолонкуРасширеннаяПодсказка" id="51"/>
@@ -168,6 +184,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Column list group add delete</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Kolumnlistgrupp lägg till ta bort</v8:content>
 									</v8:item>
 								</Title>
 								<Representation>Compact</Representation>
@@ -251,6 +271,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Table on the form</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Tabell på formuläret</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -265,6 +289,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Column list</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kolumnlista</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -281,6 +309,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>A service column was created</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>En servicekolumn skapades</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -299,6 +331,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Mark all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -308,6 +344,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Mark all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПометитьВсе</Action>
@@ -323,6 +363,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Clear all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rensa alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -332,6 +376,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Clear all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rensa alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СнятьВсе</Action>
@@ -347,6 +395,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>OK</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>OK</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -355,6 +407,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>OK</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>OK</v8:content>
 				</v8:item>
 			</ToolTip>
@@ -371,6 +427,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Move column to top</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Flytta kolumn uppåt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -380,6 +440,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Move column to top</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Flytta kolumn uppåt</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -398,6 +462,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Move column down</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Flytta kolumn nedåt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -407,6 +475,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Move column down</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Flytta kolumn nedåt</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -425,6 +497,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Add column</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg till kolumn</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -434,6 +510,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Add column</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg till kolumn</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>

--- a/VanessaAutomation/Forms/СписокТочекОстанова/Ext/Form.xml
+++ b/VanessaAutomation/Forms/СписокТочекОстанова/Ext/Form.xml
@@ -23,6 +23,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Go to line</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Gå till rad</v8:content>
+					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ФормаПерейтиРасширеннаяПодсказка" id="21"/>
 			</Button>
@@ -37,6 +41,10 @@
 					<v8:item>
 						<v8:lang>en</v8:lang>
 						<v8:content>Close</v8:content>
+					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Stäng</v8:content>
 					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ФормаЗакрытьРасширеннаяПодсказка" id="23"/>
@@ -100,6 +108,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>№</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Nr</v8:content>
+						</v8:item>
 					</Title>
 					<EditMode>EnterOnInput</EditMode>
 					<ContextMenu name="ДанныеТочекОстановаРеальныйНомерСтрокиКонтекстноеМеню" id="25"/>
@@ -131,6 +143,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Breakpoint data</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Brytpunktsdata</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -145,6 +161,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>№</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Nr</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -166,6 +186,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Line text</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Radtext</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -185,6 +209,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Widget ID</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Widget-ID</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -203,6 +231,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Real line number</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Verkligt radnummer</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -228,6 +260,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Go to editor line</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gå till redigeringsrad</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -237,6 +273,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Go to editor line</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gå till redigeringsrad</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПерейтиКСтрокеРедактора</Action>
@@ -252,6 +292,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Close form</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formulär</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -261,6 +305,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng formulär</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗакрытьФорму</Action>

--- a/VanessaAutomation/Forms/УправлениеОкномКлиентаТестирования/Ext/Form.xml
+++ b/VanessaAutomation/Forms/УправлениеОкномКлиентаТестирования/Ext/Form.xml
@@ -18,6 +18,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Group title</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Grupprubrik</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -27,6 +31,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Group title</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Grupprubrik</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Representation>None</Representation>
@@ -57,6 +65,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Form pages</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Formulärsidor</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -66,6 +78,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Form pages</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Formulärsidor</v8:content>
 				</v8:item>
 			</ToolTip>
 			<ExtendedTooltip name="СтраницыФормыРасширеннаяПодсказка" id="35"/>
@@ -80,6 +96,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Window size</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Fönsterstorlek</v8:content>
+						</v8:item>
 					</Title>
 					<ToolTip>
 						<v8:item>
@@ -89,6 +109,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Page window size</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Sida fönsterstorlek</v8:content>
 						</v8:item>
 					</ToolTip>
 					<Group>HorizontalIfPossible</Group>
@@ -104,6 +128,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Group4х3</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp4x3</v8:content>
+								</v8:item>
 							</Title>
 							<ToolTip>
 								<v8:item>
@@ -113,6 +141,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group4х3</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp4x3</v8:content>
 								</v8:item>
 							</ToolTip>
 							<Group>Vertical</Group>
@@ -152,6 +184,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Group16х9</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp16x9</v8:content>
+								</v8:item>
 							</Title>
 							<ToolTip>
 								<v8:item>
@@ -161,6 +197,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group16х9</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp16x9</v8:content>
 								</v8:item>
 							</ToolTip>
 							<Group>Vertical</Group>
@@ -200,6 +240,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Group dimensions</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Gruppdimensioner</v8:content>
+								</v8:item>
 							</Title>
 							<ToolTip>
 								<v8:item>
@@ -209,6 +253,10 @@
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group dimensions</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Gruppdimensioner</v8:content>
 								</v8:item>
 							</ToolTip>
 							<Group>Vertical</Group>
@@ -231,6 +279,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Group item</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Gruppobjekt</v8:content>
+										</v8:item>
 									</Title>
 									<ToolTip>
 										<v8:item>
@@ -240,6 +292,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Group item</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Gruppobjekt</v8:content>
 										</v8:item>
 									</ToolTip>
 									<Representation>None</Representation>
@@ -268,6 +324,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Group sizes</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Gruppstorlekar</v8:content>
+										</v8:item>
 									</Title>
 									<ToolTip>
 										<v8:item>
@@ -277,6 +337,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Group sizes</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Gruppstorlekar</v8:content>
 										</v8:item>
 									</ToolTip>
 									<Representation>None</Representation>
@@ -316,6 +380,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Screenshot</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Skärmbild</v8:content>
+						</v8:item>
 					</Title>
 					<ToolTip>
 						<v8:item>
@@ -325,6 +393,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Group picture</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Gruppbild</v8:content>
 						</v8:item>
 					</ToolTip>
 					<ExtendedTooltip name="ГруппаКартинкаРасширеннаяПодсказка" id="100"/>
@@ -346,6 +418,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Take main window screenshot</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Ta skärmbild av huvudfönstret</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="СделатьСнимокРасширеннаяПодсказка" id="105"/>
 								</Button>
@@ -360,6 +436,10 @@
 										</v8:item>
 										<v8:item>
 											<v8:lang>en</v8:lang>
+											<v8:content>50%</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
 											<v8:content>50%</v8:content>
 										</v8:item>
 									</Title>
@@ -378,6 +458,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>75%</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>75%</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="Масштаб75РасширеннаяПодсказка" id="157"/>
 								</Button>
@@ -392,6 +476,10 @@
 										</v8:item>
 										<v8:item>
 											<v8:lang>en</v8:lang>
+											<v8:content>100%</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
 											<v8:content>100%</v8:content>
 										</v8:item>
 									</Title>
@@ -419,6 +507,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Process window screenshots</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Processfönsterskärmbilder</v8:content>
+						</v8:item>
 					</Title>
 					<ExtendedTooltip name="Группа1РасширеннаяПодсказка" id="109"/>
 					<ChildItems>
@@ -439,6 +531,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Take screenshot of process windows</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Ta skärmbild av processfönster</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="СделатьСнимкиДочернихОконРасширеннаяПодсказка" id="107"/>
 								</Button>
@@ -453,6 +549,10 @@
 										</v8:item>
 										<v8:item>
 											<v8:lang>en</v8:lang>
+											<v8:content>50%</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
 											<v8:content>50%</v8:content>
 										</v8:item>
 									</Title>
@@ -471,6 +571,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>75%</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>75%</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="Масштаб75_1РасширеннаяПодсказка" id="159"/>
 								</Button>
@@ -485,6 +589,10 @@
 										</v8:item>
 										<v8:item>
 											<v8:lang>en</v8:lang>
+											<v8:content>100%</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
 											<v8:content>100%</v8:content>
 										</v8:item>
 									</Title>
@@ -594,6 +702,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Prevent from changing size</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Förhindra storleksändring</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -607,6 +719,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>Y</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>Y</v8:content>
 				</v8:item>
 			</Title>
@@ -632,6 +748,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>X</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>X</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -655,6 +775,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>H</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>H</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -673,6 +797,10 @@
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>W</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>W</v8:content>
 				</v8:item>
 			</Title>
@@ -695,6 +823,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Main window descriptor</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Huvudfönstrets deskriptor</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -715,6 +847,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Picture data</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bilddata</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -733,6 +869,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Location of add-in for screenshots</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Plats för tillägg för skärmbilder</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -753,6 +893,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Picture data</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bilddata</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -772,6 +916,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Window list</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fönsterlista</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -785,6 +933,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>window</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>window</v8:content>
 						</v8:item>
 					</Title>
@@ -807,6 +959,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Class</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Class</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -824,6 +980,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Title</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Title</v8:content>
 						</v8:item>
 					</Title>
@@ -845,6 +1005,10 @@
 							<v8:lang>en</v8:lang>
 							<v8:content>Binary picture data</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Binär bilddata</v8:content>
+						</v8:item>
 					</Title>
 					<Type/>
 				</Column>
@@ -856,6 +1020,10 @@
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Enabled</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Enabled</v8:content>
 						</v8:item>
 					</Title>
@@ -980,6 +1148,10 @@
 					<v8:lang>ro</v8:lang>
 					<v8:content>Este LINUX</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Det här är Linux</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -997,6 +1169,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>1024 х 768</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>1024 x 768</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1006,6 +1182,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Size1024х768</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Storlek1024x768</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Размер1024х768</Action>
@@ -1021,6 +1201,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>1280 х 960</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>1280 x 960</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1030,6 +1214,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Size1280х960</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Storlek1280x960</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Размер1280х960</Action>
@@ -1045,6 +1233,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>800 х 600</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>800 x 600</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1054,6 +1246,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Size800х600</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Storlek800x600</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Размер800х600</Action>
@@ -1069,6 +1265,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>960 х 720</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>960 x 720</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1078,6 +1278,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Size960х720</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Storlek960x720</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Размер960х720</Action>
@@ -1093,6 +1297,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>1024 х 576</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>1024 x 576</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1102,6 +1310,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Widescreen1024х576</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bredskärm1024x576</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Широкий1024х576</Action>
@@ -1117,6 +1329,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>1280 х 720</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>1280 x 720</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1126,6 +1342,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Widescreen1280х720</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bredskärm1280x720</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Широкий1280х720</Action>
@@ -1141,6 +1361,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>1600 х 900</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>1600 x 900</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1150,6 +1374,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Widescreen1600х900</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bredskärm1600x900</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Широкий1600х900</Action>
@@ -1165,6 +1393,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>960 х 540</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>960 x 540</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1174,6 +1406,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Widescreen960х540</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Bredskärm960x540</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Широкий960х540</Action>
@@ -1189,6 +1425,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Arbitrary size</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Godtycklig storlek</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1198,6 +1438,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Arbitrary size</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Godtycklig storlek</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПроизвольныйРазмер</Action>
@@ -1213,6 +1457,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Take screenshot</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta skärmbild</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1222,6 +1470,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Take screenshot</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta skärmbild</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СделатьСнимок</Action>
@@ -1237,6 +1489,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Take screenshots of child windows</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta skärmbilder av underordnade fönster</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1246,6 +1502,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Take screenshots of child windows</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta skärmbilder av underordnade fönster</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СделатьСнимкиДочернихОкон</Action>
@@ -1261,6 +1521,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale650</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala50</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1270,6 +1534,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale650</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala50</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Масштаб50</Action>
@@ -1285,6 +1553,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale50_1</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala50_1</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1294,6 +1566,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale650 1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala50 1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Масштаб50_1</Action>
@@ -1309,6 +1585,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale100</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala100</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1318,6 +1598,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale100</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala100</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Масштаб100</Action>
@@ -1333,6 +1617,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale100 1</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala100 1</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1342,6 +1630,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale100 1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala100 1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Масштаб100_1</Action>
@@ -1357,6 +1649,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale75</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala75</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1366,6 +1662,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale75</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala75</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Масштаб75</Action>
@@ -1381,6 +1681,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale75 1</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala75 1</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -1390,6 +1694,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Scale75 1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skala75 1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>Масштаб75_1</Action>

--- a/VanessaAutomation/Forms/УправляемаяФорма/Ext/Form.xml
+++ b/VanessaAutomation/Forms/УправляемаяФорма/Ext/Form.xml
@@ -116,6 +116,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Upload buttons features</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Ladda upp knappar funktioner</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаКнопокЗагрузитьФичиРасширеннаяПодсказка" id="1253"/>
 						<ChildItems>
@@ -312,6 +316,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Buttons newly loaded features</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Knappar nyligen laddade funktioner</v8:content>
 							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаКнопокНедавноЗагруженныеФичиРасширеннаяПодсказка" id="1256"/>
@@ -515,6 +523,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Stop</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Stopp</v8:content>
+					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ОстановитьСценарииРасширеннаяПодсказка" id="2032"/>
 			</Button>
@@ -709,6 +721,10 @@
 					<v8:item>
 						<v8:lang>en</v8:lang>
 						<v8:content>Show/hide columns</v8:content>
+					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Visa/dölj kolumner</v8:content>
 					</v8:item>
 				</ToolTip>
 				<Picture>
@@ -1327,6 +1343,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Group settings</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Gruppinställningar</v8:content>
+					</v8:item>
 				</Title>
 				<Picture>
 					<xr:Abs>Picture.png</xr:Abs>
@@ -1376,6 +1396,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Expand all lines of the tree</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Expandera alla rader i trädet</v8:content>
+					</v8:item>
 				</Title>
 				<LocationInCommandBar>InAdditionalSubmenu</LocationInCommandBar>
 				<ExtendedTooltip name="ФормаРазвернутьВсеСтрокиДереваСлужебныйРасширеннаяПодсказка" id="2947"/>
@@ -1395,6 +1419,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Tools</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Verktyg</v8:content>
+					</v8:item>
 				</Title>
 				<ToolTip>
 					<v8:item>
@@ -1404,6 +1432,10 @@
 					<v8:item>
 						<v8:lang>en</v8:lang>
 						<v8:content>Tools</v8:content>
+					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Verktyg</v8:content>
 					</v8:item>
 				</ToolTip>
 				<Picture>
@@ -1423,6 +1455,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Steps library</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Stegbibliotek</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorБиблиотекаШаговРасширеннаяПодсказка" id="2953"/>
 						<ChildItems>
@@ -1437,6 +1473,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Steps library</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Stegbibliotek</v8:content>
 									</v8:item>
 								</Title>
 								<ExtendedTooltip name="VanessaEditorДобавитьИзвестныйШагРасширеннаяПодсказка" id="2951"/>
@@ -1458,6 +1498,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Group vanessa editor smoke tests</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Grupp Vanessa-redigerare röktester</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorДымовыеТестыРасширеннаяПодсказка" id="3987"/>
 						<ChildItems>
@@ -1473,6 +1517,10 @@
 										<v8:lang>en</v8:lang>
 										<v8:content>Smoke tests generator</v8:content>
 									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Röktestgenerator</v8:content>
+									</v8:item>
 								</Title>
 								<ExtendedTooltip name="VanessaEditorОткрытьФормуГенератораСценариевРасширеннаяПодсказка" id="3989"/>
 							</Button>
@@ -1487,6 +1535,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Test data generator</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Testdatagenerator</v8:content>
 							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorПодготовкаИЗагрузкаДанныхРасширеннаяПодсказка" id="2935"/>
@@ -1513,6 +1565,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Form state</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Formulärtillstånd</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorСостояниеФормыРасширеннаяПодсказка" id="2894"/>
 						<ChildItems>
@@ -1538,6 +1594,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Form changes</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Formulärändringar</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorПолучитьИзмененияФормыРасширеннаяПодсказка" id="2896"/>
 						<ChildItems>
@@ -1552,6 +1612,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Get the whole form state</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Hämta hela formulärtillståndet</v8:content>
 									</v8:item>
 								</Title>
 								<ExtendedTooltip name="VanessaEditorПолучитьИзмененияФормыGherkinРасширеннаяПодсказка" id="2898"/>
@@ -1593,6 +1657,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Group save form state</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Grupp spara formulärtillstånd</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -1602,6 +1670,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Group save form state</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Grupp spara formulärtillstånd</v8:content>
 							</v8:item>
 						</ToolTip>
 						<ExtendedTooltip name="ГруппаVanessaEditorСохранитьСостояниеФормыРасширеннаяПодсказка" id="3143"/>
@@ -1628,6 +1700,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Variables board</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Variabeltavla</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorТаблоПеременныхРасширеннаяПодсказка" id="2929"/>
 						<ChildItems>
@@ -1647,6 +1723,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Compare with another feature file</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Jämför med en annan feature-fil</v8:content>
 							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorСравнитьСДругимФичаФайломРасширеннаяПодсказка" id="3026"/>
@@ -1668,6 +1748,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Vanessa editor group show allure report</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Vanessa-redigerargrupp visa Allure-rapport</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorПоказатьОтчетAllureРасширеннаяПодсказка" id="3034"/>
 						<ChildItems>
@@ -1687,6 +1771,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Vanessa editor group to voice line</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Vanessa-redigerargrupp röstläsning av rad</v8:content>
 							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorОзвучитьСтрокуРасширеннаяПодсказка" id="3107"/>
@@ -1708,6 +1796,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Group show brief information about step</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Grupp visa kort information om steg</v8:content>
+							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorПоказатьКраткуюИнформациюОШагеРасширеннаяПодсказка" id="3921"/>
 						<ChildItems>
@@ -1727,6 +1819,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Vanessa editor group get the coordinates of the area</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Vanessa-redigerargrupp hämta koordinaterna för området</v8:content>
 							</v8:item>
 						</Title>
 						<ExtendedTooltip name="ГруппаVanessaEditorПолучитьКоординатыОбластиРасширеннаяПодсказка" id="3252"/>
@@ -1749,6 +1845,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Vanessa editor group working with the browser</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Vanessa-redigerargrupp arbeta med webbläsaren</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -1758,6 +1858,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Vanessa editor group working with browser</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Vanessa-redigerargrupp arbeta med webbläsare</v8:content>
 							</v8:item>
 						</ToolTip>
 						<ExtendedTooltip name="ГруппаVanessaEditorРаботаСБраузеромРасширеннаяПодсказка" id="3749"/>
@@ -1781,6 +1885,10 @@
 						<v8:lang>en</v8:lang>
 						<v8:content>Command panel vanessa editor</v8:content>
 					</v8:item>
+					<v8:item>
+						<v8:lang>sv</v8:lang>
+						<v8:content>Kommandopanel Vanessa-redigerare</v8:content>
+					</v8:item>
 				</Title>
 				<ExtendedTooltip name="ГруппаКоманднаяПанельVanessaEditorРасширеннаяПодсказка" id="2425"/>
 				<ChildItems>
@@ -1793,6 +1901,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Go to file differences</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Gå till filskillnader</v8:content>
 							</v8:item>
 						</Title>
 						<Representation>Compact</Representation>
@@ -1820,6 +1932,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Directory tree</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Katalogträd</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -1829,6 +1945,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Directory tree</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Katalogträd</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -1863,6 +1983,10 @@
 										<v8:lang>en</v8:lang>
 										<v8:content>Editor settings</v8:content>
 									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Redigerarinställningar</v8:content>
+									</v8:item>
 								</Title>
 								<ToolTip>
 									<v8:item>
@@ -1872,6 +1996,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Editor settings</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Redigerarinställningar</v8:content>
 									</v8:item>
 								</ToolTip>
 								<Picture>
@@ -1890,6 +2018,10 @@
 											<v8:item>
 												<v8:lang>en</v8:lang>
 												<v8:content>Group settings</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Gruppinställningar</v8:content>
 											</v8:item>
 										</Title>
 										<ExtendedTooltip name="ПанельVanessaEditorФормаГруппаНастройкиРасширеннаяПодсказка" id="2723"/>
@@ -1967,6 +2099,10 @@
 												<v8:lang>en</v8:lang>
 												<v8:content>Visibility of editor panel buttons</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Synlighet för redigerarens panelknappar</v8:content>
+											</v8:item>
 										</Title>
 										<ExtendedTooltip name="ГруппаVanessaEditorВидимостьКнопокПанелиРедактораРасширеннаяПодсказка" id="2847"/>
 										<ChildItems>
@@ -1990,6 +2126,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Run scenarios</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Kör scenarier</v8:content>
 							</v8:item>
 						</Title>
 						<Representation>Compact</Representation>
@@ -2096,6 +2236,10 @@
 										<v8:lang>en</v8:lang>
 										<v8:content>Load features</v8:content>
 									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Ladda funktioner</v8:content>
+									</v8:item>
 								</ToolTip>
 								<Picture>
 									<xr:Ref>StdPicture.OpenFile</xr:Ref>
@@ -2114,6 +2258,10 @@
 												<v8:lang>en</v8:lang>
 												<v8:content>Upload buttons features</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Ladda upp knappar funktioner</v8:content>
+											</v8:item>
 										</Title>
 										<ExtendedTooltip name="ГруппаКнопокVanessaEditorЗагрузитьФичиРасширеннаяПодсказка" id="2703"/>
 										<ChildItems>
@@ -2127,6 +2275,10 @@
 														<v8:lang>en</v8:lang>
 														<v8:content>Download features buttons</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Knappar för att ladda ner funktioner</v8:content>
+													</v8:item>
 												</Title>
 												<ToolTip>
 													<v8:item>
@@ -2136,6 +2288,10 @@
 													<v8:item>
 														<v8:lang>en</v8:lang>
 														<v8:content>Download features buttons</v8:content>
+													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Knappar för att ladda ner funktioner</v8:content>
 													</v8:item>
 												</ToolTip>
 												<ExtendedTooltip name="ГруппаКнопокVanessaEditorКнопкиЗагрузитьФичиРасширеннаяПодсказка" id="3160"/>
@@ -2334,6 +2490,10 @@
 														<v8:lang>en</v8:lang>
 														<v8:content>Load other buttons</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Ladda övriga knappar</v8:content>
+													</v8:item>
 												</Title>
 												<ToolTip>
 													<v8:item>
@@ -2343,6 +2503,10 @@
 													<v8:item>
 														<v8:lang>en</v8:lang>
 														<v8:content>Load other buttons</v8:content>
+													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Ladda övriga knappar</v8:content>
 													</v8:item>
 												</ToolTip>
 												<ExtendedTooltip name="ГруппаКнопокVanessaEditorКнопкиЗагрузитьПрочееРасширеннаяПодсказка" id="3162"/>
@@ -2370,6 +2534,10 @@
 											<v8:item>
 												<v8:lang>en</v8:lang>
 												<v8:content>Buttons newly loaded features</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Knappar nyligen laddade funktioner</v8:content>
 											</v8:item>
 										</Title>
 										<ExtendedTooltip name="ГруппаКнопокVanessaEditorНедавноЗагруженныеФичиРасширеннаяПодсказка" id="2709"/>
@@ -2400,6 +2568,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Save file as</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Spara fil som</v8:content>
 									</v8:item>
 								</Title>
 								<ExtendedTooltip name="ПанельVanessaEditorСохранитьФайлКакРасширеннаяПодсказка" id="2853"/>
@@ -2711,6 +2883,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Training</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Utbildning</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -2720,6 +2896,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Training</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Utbildning</v8:content>
 							</v8:item>
 						</ToolTip>
 						<ExtendedTooltip name="ГруппаVanessaEditorОбучениеРасширеннаяПодсказка" id="3136"/>
@@ -2745,6 +2925,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Clipboard</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Urklipp</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -2754,6 +2938,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Clipboard</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Urklipp</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -2798,6 +2986,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Text changes</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Textändringar</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -2807,6 +2999,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Text changes</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Textändringar</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -2834,6 +3030,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Search</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Sök</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -2843,6 +3043,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Search</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Sök</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -2858,6 +3062,10 @@
 										<v8:lang>en</v8:lang>
 										<v8:content>Collapse steps</v8:content>
 									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Fäll ihop steg</v8:content>
+									</v8:item>
 								</Title>
 								<ToolTip>
 									<v8:item>
@@ -2867,6 +3075,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Collapse steps</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Fäll ihop steg</v8:content>
 									</v8:item>
 								</ToolTip>
 								<Picture>
@@ -2887,6 +3099,10 @@
 											<v8:item>
 												<v8:lang>en</v8:lang>
 												<v8:content>Collapse all</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Fäll ihop alla</v8:content>
 											</v8:item>
 										</Title>
 										<ExtendedTooltip name="VanessaEditorViewFoldAllРасширеннаяПодсказка" id="2453"/>
@@ -2928,6 +3144,10 @@
 												<v8:lang>en</v8:lang>
 												<v8:content>Expand all</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Expandera alla</v8:content>
+											</v8:item>
 										</Title>
 										<ExtendedTooltip name="VanessaEditorViewUnfoldAllРасширеннаяПодсказка" id="2461"/>
 									</Button>
@@ -2943,6 +3163,10 @@
 										<v8:lang>en</v8:lang>
 										<v8:content>Search</v8:content>
 									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Sök</v8:content>
+									</v8:item>
 								</Title>
 								<ToolTip>
 									<v8:item>
@@ -2952,6 +3176,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Search</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Sök</v8:content>
 									</v8:item>
 								</ToolTip>
 								<Picture>
@@ -3011,6 +3239,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Breakpoints</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Brytpunkter</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -3020,6 +3252,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Breakpoints</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Brytpunkter</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -3064,6 +3300,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Actions in the editor</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Åtgärder i redigeraren</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -3073,6 +3313,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Actions in the editor</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Åtgärder i redigeraren</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -3099,6 +3343,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>User actions recording</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Inspelning av användaråtgärder</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -3108,6 +3356,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>User actions recording</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Inspelning av användaråtgärder</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -3410,6 +3662,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Video/audio</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Video/ljud</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -3419,6 +3675,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Video/audio</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Video/ljud</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -3456,6 +3716,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Scale</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Skala</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -3465,6 +3729,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Scale</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Skala</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -3506,6 +3774,10 @@
 										<v8:lang>en</v8:lang>
 										<v8:content>Theme selection</v8:content>
 									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Temaval</v8:content>
+									</v8:item>
 								</Title>
 								<ToolTip>
 									<v8:item>
@@ -3515,6 +3787,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Theme selection</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Temaval</v8:content>
 									</v8:item>
 								</ToolTip>
 								<Picture>
@@ -3558,6 +3834,10 @@
 								<v8:lang>en</v8:lang>
 								<v8:content>Processing script lines</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Bearbetning av skriptrader</v8:content>
+							</v8:item>
 						</Title>
 						<ToolTip>
 							<v8:item>
@@ -3567,6 +3847,10 @@
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Processing script lines</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Bearbetning av skriptrader</v8:content>
 							</v8:item>
 						</ToolTip>
 						<Representation>Compact</Representation>
@@ -3608,6 +3892,10 @@
 									<v8:item>
 										<v8:lang>en</v8:lang>
 										<v8:content>Translate</v8:content>
+									</v8:item>
+									<v8:item>
+										<v8:lang>sv</v8:lang>
+										<v8:content>Översätt</v8:content>
 									</v8:item>
 								</Title>
 								<ExtendedTooltip name="VanessaEditorПеревестиТекстНаДругойЯзыкРасширеннаяПодсказка" id="2565"/>
@@ -3656,6 +3944,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Functionality</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Funktionalitet</v8:content>
+				</v8:item>
 			</Title>
 			<Group>Vertical</Group>
 			<ShowTitle>false</ShowTitle>
@@ -3670,6 +3962,10 @@
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Tab functionality</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Flikfunktionalitet</v8:content>
 						</v8:item>
 					</Title>
 					<PagesRepresentation>TabsOnRightHorizontal</PagesRepresentation>
@@ -3777,6 +4073,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Pages for displaying the tree and editor</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Sidor för visning av trädet och redigeraren</v8:content>
+										</v8:item>
 									</Title>
 									<PagesRepresentation>None</PagesRepresentation>
 									<ExtendedTooltip name="СтраницыДляОтображенияДереваИРедактораРасширеннаяПодсказка" id="2417"/>
@@ -3790,6 +4090,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Step tree</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Stegträd</v8:content>
 												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаДеревоШаговРасширеннаяПодсказка" id="2419"/>
@@ -3816,6 +4120,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Tests tree</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Testträd</v8:content>
+														</v8:item>
 													</Title>
 													<SearchStringLocation>None</SearchStringLocation>
 													<SearchControlLocation>None</SearchControlLocation>
@@ -3831,6 +4139,10 @@
 																	<v8:item>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Basic commands</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Grundläggande kommandon</v8:content>
 																	</v8:item>
 																</Title>
 																<ExtendedTooltip name="ГруппаОсновнаяРасширеннаяПодсказка" id="1263"/>
@@ -4393,6 +4705,10 @@
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Open feature file in editor</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Öppna feature-fil i redigeraren</v8:content>
+																	</v8:item>
 																</Title>
 																<ExtendedTooltip name="ОткрытьФичаФайлВРедактореРасширеннаяПодсказка" id="1470"/>
 																<ChildItems>
@@ -4589,6 +4905,10 @@
 																	<v8:item>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Collapse</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Fäll ihop</v8:content>
 																	</v8:item>
 																</Title>
 																<ExtendedTooltip name="ГруппаСвернутьРасширеннаяПодсказка" id="1270"/>
@@ -4787,6 +5107,10 @@
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Collapse to first level steps</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Fäll ihop till första nivåns steg</v8:content>
+																			</v8:item>
 																		</Title>
 																		<ExtendedTooltip name="ДеревоТестовКонтекстноеМенюСвернутьДоШаговРасширеннаяПодсказка" id="1876"/>
 																	</Button>
@@ -4801,6 +5125,10 @@
 																	<v8:item>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Errors processing</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Felbearbetning</v8:content>
 																	</v8:item>
 																</Title>
 																<ExtendedTooltip name="РаботаСОшибкамиРасширеннаяПодсказка" id="2028"/>
@@ -4821,6 +5149,10 @@
 																	<v8:item>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Breakpoints</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Brytpunkter</v8:content>
 																	</v8:item>
 																</Title>
 																<ExtendedTooltip name="ГруппаБрейкпоинтыРасширеннаяПодсказка" id="1479"/>
@@ -5732,6 +6064,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Vanessa Editor</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Vanessa-redigerare</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаVanessaEditorРасширеннаяПодсказка" id="2421"/>
 											<ChildItems>
@@ -5744,6 +6080,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Editor and file tree</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Redigerare och filträd</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Horizontal</Group>
@@ -5760,6 +6100,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>File tree</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Filträd</v8:content>
 																</v8:item>
 															</Title>
 															<Width>20</Width>
@@ -5779,6 +6123,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Features directory path</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Sökväg till feature-katalog</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>None</TitleLocation>
 																	<ToolTip>
@@ -5789,6 +6137,10 @@
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Features directory path</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Sökväg till feature-katalog</v8:content>
 																		</v8:item>
 																	</ToolTip>
 																	<ToolTipRepresentation>None</ToolTipRepresentation>
@@ -5802,6 +6154,10 @@
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Features directory path</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Sökväg till feature-katalog</v8:content>
 																		</v8:item>
 																	</InputHint>
 																	<ContextMenu name="ПутьКПапкеСФичамиКонтекстноеМеню" id="2571"/>
@@ -5822,6 +6178,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Search string</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Söksträng</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>None</TitleLocation>
 																	<ToolTip>
@@ -5831,6 +6191,10 @@
 																		</v8:item>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
+																			<v8:content>Filter</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
 																			<v8:content>Filter</v8:content>
 																		</v8:item>
 																	</ToolTip>
@@ -5844,6 +6208,10 @@
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Enter a search text or a phrase part</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Ange en söktext eller en del av en fras</v8:content>
 																		</v8:item>
 																	</InputHint>
 																	<ContextMenu name="СтрокаДляПоискаВнутриФичиКонтекстноеМеню" id="2696"/>
@@ -5870,6 +6238,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Directory tree</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Katalogträd</v8:content>
+																		</v8:item>
 																	</Title>
 																	<CommandSet>
 																		<ExcludedCommand>Add</ExcludedCommand>
@@ -5882,6 +6254,10 @@
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>File tree</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Filträd</v8:content>
 																		</v8:item>
 																	</ToolTip>
 																	<ContextMenu name="ДревоФайлаФичКонтекстноеМеню" id="2574">
@@ -5936,6 +6312,10 @@
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Tree lines</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Trädlinjer</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>InCell</Group>
 																			<ExtendedTooltip name="ДревоФайлаФичСтрокиРасширеннаяПодсказка" id="2593"/>
@@ -5951,6 +6331,10 @@
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Picture</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Bild</v8:content>
+																						</v8:item>
 																					</Title>
 																					<ToolTip>
 																						<v8:item>
@@ -5960,6 +6344,10 @@
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>File tree</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Filträd</v8:content>
 																						</v8:item>
 																					</ToolTip>
 																					<EditMode>EnterOnInput</EditMode>
@@ -5977,6 +6365,10 @@
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Name</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Namn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<EditMode>EnterOnInput</EditMode>
@@ -5999,6 +6391,10 @@
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Git</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Git</v8:content>
+																</v8:item>
 															</Title>
 															<Width>27</Width>
 															<Group>Vertical</Group>
@@ -6017,6 +6413,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Git folder</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Git-mapp</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>None</TitleLocation>
 																	<ToolTip>
@@ -6027,6 +6427,10 @@
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Git folder</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Git-mapp</v8:content>
 																		</v8:item>
 																	</ToolTip>
 																	<AutoMaxWidth>false</AutoMaxWidth>
@@ -6048,6 +6452,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Button group tree git command bar</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Knappgrupp trädets git-kommandofält</v8:content>
+																		</v8:item>
 																	</Title>
 																	<ExtendedTooltip name="ГруппаКнопокДеревоGitКоманднаяПанельРасширеннаяПодсказка" id="2835"/>
 																	<ChildItems>
@@ -6060,6 +6468,10 @@
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Git tree button group</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Git-trädets knappgrupp</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Representation>Compact</Representation>
@@ -6084,6 +6496,10 @@
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Refresh</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Uppdatera</v8:content>
+																						</v8:item>
 																					</Title>
 																					<ExtendedTooltip name="ДеревоGitОбновитьРасширеннаяПодсказка" id="2822"/>
 																				</Button>
@@ -6103,6 +6519,10 @@
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Stage Selected</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Staga markerade</v8:content>
 																						</v8:item>
 																					</Title>
 																					<ExtendedTooltip name="ДеревоGitДобавитьВИндексРасширеннаяПодсказка" id="2824"/>
@@ -6124,6 +6544,10 @@
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Unstage Selected</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Avstaga markerade</v8:content>
+																						</v8:item>
 																					</Title>
 																					<ExtendedTooltip name="ДеревоGitДеревоGitУбратьИзИндексаРасширеннаяПодсказка" id="2828"/>
 																				</Button>
@@ -6142,6 +6566,10 @@
 																						</v8:item>
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
+																							<v8:content>Commit</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
 																							<v8:content>Commit</v8:content>
 																						</v8:item>
 																					</Title>
@@ -6178,6 +6606,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Message text</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Meddelandetext</v8:content>
+																		</v8:item>
 																	</ToolTip>
 																	<AutoMaxWidth>false</AutoMaxWidth>
 																	<Height>3</Height>
@@ -6207,6 +6639,10 @@
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Git tree</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Git-träd</v8:content>
 																		</v8:item>
 																	</Title>
 																	<ContextMenu name="ДеревоGitКонтекстноеМеню" id="2804"/>
@@ -6260,6 +6696,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Git button footer</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Git-knappsidfot</v8:content>
+																		</v8:item>
 																	</Title>
 																	<HorizontalStretch>true</HorizontalStretch>
 																	<Group>AlwaysHorizontal</Group>
@@ -6299,6 +6739,10 @@
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Pull</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Pull</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ExtendedTooltip name="ДеревоGitPullРасширеннаяПодсказка" id="2857"/>
 																		</Button>
@@ -6322,6 +6766,10 @@
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Push</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Push</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ExtendedTooltip name="ДеревоGitPushРасширеннаяПодсказка" id="2859"/>
 																		</Button>
@@ -6338,6 +6786,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Vanessa editor group</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerargrupp</v8:content>
 																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
@@ -6356,6 +6808,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Editor</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Redigerare</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>None</TitleLocation>
 																	<Width>80</Width>
@@ -6371,6 +6827,10 @@
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Breakpoints</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Brytpunkter</v8:content>
 																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorПодборШагаРасширеннаяПодсказка" id="2530"/>
@@ -6391,6 +6851,10 @@
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Execute script/step</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Kör skript/steg</v8:content>
 																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorОсновнаяРасширеннаяПодсказка" id="2483"/>
@@ -6498,6 +6962,10 @@
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Run from current step with continuation</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Kör från aktuellt steg med fortsättning</v8:content>
+																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="VanessaEditorКонтекстноеМенюВыполнитьДанныйСценарийСТекущегоШагаСПродолжениемРасширеннаяПодсказка" id="2563"/>
 																					</Button>
@@ -6512,6 +6980,10 @@
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Selected lines</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Markerade rader</v8:content>
 																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="VanessaEditorКонтекстноеМенюВыполнитьВыделенныеСтрокиРасширеннаяПодсказка" id="2423"/>
@@ -6710,6 +7182,10 @@
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Open feature file in editor</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Öppna feature-fil i redigeraren</v8:content>
+																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorРаботаСФичейРасширеннаяПодсказка" id="2485"/>
 																				<ChildItems>
@@ -6724,6 +7200,10 @@
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Open subscript in a new tab</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Öppna underskript i ny flik</v8:content>
 																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="VanessaEditorКонтекстноеМенюОткрытьПодсценарийВНовойВкладкеРасширеннаяПодсказка" id="2737"/>
@@ -6831,6 +7311,10 @@
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Open .feature file directory</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Öppna .feature-filkatalog</v8:content>
+																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="VanessaEditorКонтекстноеМенюОткрытьКаталогФичиРасширеннаяПодсказка" id="2489"/>
 																					</Button>
@@ -6845,6 +7329,10 @@
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Breakpoints</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Brytpunkter</v8:content>
 																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorБрейкпоинтыРасширеннаяПодсказка" id="2495"/>
@@ -6861,6 +7349,10 @@
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Set/remove breakpoint</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Sätt/ta bort brytpunkt</v8:content>
+																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="VanessaEditorКонтекстноеМенюБрейкпоинтРасширеннаяПодсказка" id="2497"/>
 																					</Button>
@@ -6875,6 +7367,10 @@
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Remove all breakpoints</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Ta bort alla brytpunkter</v8:content>
 																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="VanessaEditorКонтекстноеМенюБрейкпоинтУбратьВсеРасширеннаяПодсказка" id="2499"/>
@@ -6891,6 +7387,10 @@
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Steps receiving group</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Stegmottagningsgrupp</v8:content>
+																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="VanessaEditorКонтекстноеМенюГруппаПолученияШаговРасширеннаяПодсказка" id="3956"/>
 																				<ChildItems>
@@ -6903,6 +7403,10 @@
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Get a step</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Hämta ett steg</v8:content>
 																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorПодменюПолучитьШагРасширеннаяПодсказка" id="2547"/>
@@ -7037,6 +7541,10 @@
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Replace step</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Ersätt steg</v8:content>
+																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="VanessaEditorКонтекстноеМенюГруппаЗаменитьШагРасширеннаяПодсказка" id="4049"/>
 																				<ChildItems>
@@ -7057,6 +7565,10 @@
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Breakpoints</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Brytpunkter</v8:content>
+																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorРаботаСТаблицамиРасширеннаяПодсказка" id="2507"/>
 																				<ChildItems>
@@ -7071,6 +7583,10 @@
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Edit table</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Redigera tabell</v8:content>
 																							</v8:item>
 																						</Title>
 																						<ExtendedTooltip name="VanessaEditorКонтекстноеМенюРедактироватьТаблицуТекстРасширеннаяПодсказка" id="2509"/>
@@ -7092,6 +7608,10 @@
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Open feature file in editor</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Öppna feature-fil i redigeraren</v8:content>
+																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorНавигацияРасширеннаяПодсказка" id="2599"/>
 																				<ChildItems>
@@ -7111,6 +7631,10 @@
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Vanessa Editor context menu group</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Vanessa-redigerare snabbmenygrupp</v8:content>
 																					</v8:item>
 																				</Title>
 																				<ExtendedTooltip name="ГруппаКонтекстногоМенюVanessaEditorМенюExtendedTooltip" id="3120"/>
@@ -7236,6 +7760,10 @@
 									<v8:lang>en</v8:lang>
 									<v8:content>Group generation</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp generering</v8:content>
+								</v8:item>
 							</ToolTip>
 							<ExtendedTooltip name="ГруппаГенерацияEPFРасширеннаяПодсказка" id="1289"/>
 							<ChildItems>
@@ -7248,6 +7776,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Creation buttons</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Skapandeknappar</v8:content>
 										</v8:item>
 									</Title>
 									<Group>Horizontal</Group>
@@ -7542,6 +8074,10 @@
 												<v8:lang>en</v8:lang>
 												<v8:content>The checkbox defines which form will be generated upon creating epf. Select this checkbox to operate with managed applications.</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Kryssrutan anger vilket formulär som genereras vid skapande av epf. Markera denna kryssruta för att arbeta med hanterade applikationer.</v8:content>
+											</v8:item>
 										</Title>
 									</ExtendedTooltip>
 								</CheckBoxField>
@@ -7646,6 +8182,10 @@
 											<v8:item>
 												<v8:lang>en</v8:lang>
 												<v8:content>The checkbox defines that regions will be created in the code of epf being created</v8:content>
+											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Kryssrutan anger att regioner kommer att skapas i koden för den epf som skapas</v8:content>
 											</v8:item>
 										</Title>
 									</ExtendedTooltip>
@@ -7753,6 +8293,10 @@
 												<v8:lang>en</v8:lang>
 												<v8:content>Obsolete. No need to use this checkbox.</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Föråldrad. Ingen anledning att använda denna kryssruta.</v8:content>
+											</v8:item>
 										</Title>
 									</ExtendedTooltip>
 								</CheckBoxField>
@@ -7858,6 +8402,10 @@
 												<v8:lang>en</v8:lang>
 												<v8:content>If the checkbox is on, generated code will be displayed instead of re-creating the epf (if it existed).</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>Om kryssrutan är aktiverad visas genererad kod istället för att återskapa epf (om den existerade).</v8:content>
+											</v8:item>
 										</Title>
 									</ExtendedTooltip>
 								</CheckBoxField>
@@ -7870,6 +8418,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Platform version</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Plattformsversion</v8:content>
 										</v8:item>
 									</Title>
 									<Width>28</Width>
@@ -8068,6 +8620,12 @@
 1. Thick client must be installed.
 2. The field must contain platform version to be used for initial creating and re-creating of the epf.</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Eftersom batchstart av Designer används för att skapa epf, då:
+1. Tjock klient måste vara installerad.
+2. Fältet måste innehålla plattformsversionen som ska användas för initialt skapande och återskapande av epf.</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 											<Events>
@@ -8089,6 +8647,11 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>1. A thick client must be installed.
 2. The launch of file databases on this PC should work.</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>"1. En tjock klient måste vara installerad.
+2. Start av fildatabaser på denna dator ska fungera."</v8:content>
 										</v8:item>
 									</Title>
 									<ContextMenu name="ДекорацияТребованияКГенерацииEPFКонтекстноеМеню" id="3259"/>
@@ -8195,6 +8758,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Re-code library</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Omkoda bibliotek</v8:content>
+										</v8:item>
 									</Title>
 									<Group>Vertical</Group>
 									<ExtendedTooltip name="БиблиотекиПовторногоКодаРасширеннаяПодсказка" id="1296"/>
@@ -8211,6 +8778,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>For Vanessa Automation Single, no standard libraries need to be added. They are already included in the main file.</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>För Vanessa Automation Single behöver inga standardbibliotek läggas till. De ingår redan i huvudfilen.</v8:content>
 												</v8:item>
 											</Title>
 											<ContextMenu name="НадписьНеНадоДобавлятьБиблиотекиКонтекстноеМеню" id="3233"/>
@@ -8234,6 +8805,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Library directories</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Bibliotekskataloger</v8:content>
+												</v8:item>
 											</Title>
 											<ToolTip>
 												<v8:item>
@@ -8243,6 +8818,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Library directories</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Bibliotekskataloger</v8:content>
 												</v8:item>
 											</ToolTip>
 											<SearchStringLocation>None</SearchStringLocation>
@@ -8451,6 +9030,10 @@
 														<v8:lang>en</v8:lang>
 														<v8:content>List of directories that contain epf files containing script steps and feature files containing export scripts.</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Lista över kataloger som innehåller epf-filer med skriptsteg och feature-filer med exportskript.</v8:content>
+													</v8:item>
 												</Title>
 											</ExtendedTooltip>
 											<SearchStringAddition name="КаталогиБиблиотекСтрокаПоиска" id="1298">
@@ -8493,6 +9076,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Value</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Värde</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 													<EditMode>EnterOnInput</EditMode>
@@ -8523,6 +9110,10 @@
 													<v8:item>
 														<v8:lang>ru</v8:lang>
 														<v8:content>В списке указываются пути к формам внутри конфигурации, содержащим описания шагов.</v8:content>
+													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Listan innehåller sökvägar till formulär inom konfigurationen som innehåller stegbeskrivningar.</v8:content>
 													</v8:item>
 												</Title>
 											</ExtendedTooltip>
@@ -8630,6 +9221,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Collaborations with UI</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Samarbeten med gränssnitt</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="РаботасUIРасширеннаяПодсказка" id="1309"/>
 									<ChildItems>
@@ -8642,6 +9237,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Test client button group</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Testklientknappgrupp</v8:content>
 												</v8:item>
 											</Title>
 											<Representation>Compact</Representation>
@@ -9430,6 +10029,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Get the whole form state in steps</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Hämta hela formulärtillståndet i steg</v8:content>
+														</v8:item>
 													</Title>
 													<ExtendedTooltip name="ПолучитьИзмененияФормыGherkinРасширеннаяПодсказка" id="1318"/>
 												</Button>
@@ -9452,6 +10055,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Smoke tests</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Röktester</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="ОткрытьФормуГенератораСценариевРасширеннаяПодсказка" id="2067"/>
 										</Button>
@@ -9467,6 +10074,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Automated scenario creation</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Automatiserat scenarioskapande</v8:content>
+										</v8:item>
 									</Title>
 									<Group>Vertical</Group>
 									<ExtendedTooltip name="АвтоматизированноеСозданиеСценариевРасширеннаяПодсказка" id="1320"/>
@@ -9480,6 +10091,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Generation result</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Genereringsresultat</v8:content>
 												</v8:item>
 											</Title>
 											<ExtendedTooltip name="РезультатГенерацииРасширеннаяПодсказка" id="1321"/>
@@ -9582,6 +10197,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Commands</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Kommandon</v8:content>
 																</v8:item>
 															</Title>
 															<HorizontalStretch>false</HorizontalStretch>
@@ -9787,6 +10406,10 @@
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group actions with code</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp åtgärder med kod</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>Horizontal</Group>
 																	<Representation>None</Representation>
@@ -9811,6 +10434,10 @@
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Comment lines of the script</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Kommentera rader i skriptet</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ExtendedTooltip name="КомментироватьСтрокиСценарияРасширеннаяПодсказка" id="2225"/>
 																		</Button>
@@ -9831,6 +10458,10 @@
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Highlight code like embedded language</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Markera kod som inbäddat språk</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ExtendedTooltip name="ВыделитьСтрокиСценарияРасширеннаяПодсказка" id="2227"/>
 																		</Button>
@@ -9849,6 +10480,10 @@
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Generated script</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Genererat skript</v8:content>
+																</v8:item>
 															</Title>
 															<TitleLocation>None</TitleLocation>
 															<ContextMenu name="СгенерированныйСценарийКонтекстноеМеню" id="315">
@@ -9863,6 +10498,10 @@
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Generated scenario context menu actions with code</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Genererat scenario snabbmenyåtgärder med kod</v8:content>
+																			</v8:item>
 																		</Title>
 																		<ToolTip>
 																			<v8:item>
@@ -9872,6 +10511,10 @@
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Generated scenario context menu actions with code</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Genererat scenario snabbmenyåtgärder med kod</v8:content>
 																			</v8:item>
 																		</ToolTip>
 																		<ExtendedTooltip name="СгенерированныйСценарийКонтекстноеМенюДействияСКодомРасширеннаяПодсказка" id="3092"/>
@@ -9907,6 +10550,10 @@
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Edit table</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Redigera tabell</v8:content>
 																			</v8:item>
 																		</Title>
 																		<ExtendedTooltip name="СгенерированныйСценарийКонтекстноеМенюРедактироватьТаблицуТекстРасширеннаяПодсказка" id="1604"/>
@@ -10026,6 +10673,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Code</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Kod</v8:content>
 																</v8:item>
 															</Title>
 															<TitleLocation>None</TitleLocation>
@@ -10219,6 +10870,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Code</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Kod</v8:content>
 																</v8:item>
 															</Title>
 															<TitleLocation>None</TitleLocation>
@@ -10416,6 +11071,10 @@
 																</v8:item>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
+																	<v8:content>XML</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
 																	<v8:content>XML</v8:content>
 																</v8:item>
 															</Title>
@@ -11085,6 +11744,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>TestClients data</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>TestClients-data</v8:content>
+										</v8:item>
 									</Title>
 									<ToolTip>
 										<v8:item>
@@ -11094,6 +11757,10 @@
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>TestClients data</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>TestClients-data</v8:content>
 										</v8:item>
 									</ToolTip>
 									<ToolTipRepresentation>Button</ToolTipRepresentation>
@@ -11343,6 +12010,10 @@
 														<v8:lang>en</v8:lang>
 														<v8:content>Test client group 1</v8:content>
 													</v8:item>
+													<v8:item>
+														<v8:lang>sv</v8:lang>
+														<v8:content>Testklientgrupp 1</v8:content>
+													</v8:item>
 												</Title>
 												<Representation>Compact</Representation>
 												<ExtendedTooltip name="ТестКлиентГруппа1РасширеннаяПодсказка" id="1336"/>
@@ -11488,6 +12159,17 @@
 6. Имя компьютера для установления подключения
 7. Порт</v8:content>
 											</v8:item>
+											<v8:item>
+												<v8:lang>sv</v8:lang>
+												<v8:content>En lista med testklienter som anger:
+1. Profilnamn
+2. Synonym
+3. Testklienttyp
+4. Anslutningssträng till databasen
+5. Ytterligare startalternativ
+6. Datornamn för att upprätta anslutning
+7. Port</v8:content>
+											</v8:item>
 										</Title>
 									</ExtendedTooltip>
 									<SearchStringAddition name="ДанныеКлиентовТестированияСтрокаПоиска" id="1342">
@@ -11534,6 +12216,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Sign that the given string corresponds to the test manager</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Tecken på att den angivna strängen motsvarar testhanteraren</v8:content>
+												</v8:item>
 											</ToolTip>
 											<EditMode>EnterOnInput</EditMode>
 											<HorizontalStretch>false</HorizontalStretch>
@@ -11555,6 +12241,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Customer data testing group 4</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Kunddatatestgrupp 4</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="ДанныеКлиентовТестированияГруппа4РасширеннаяПодсказка" id="1726"/>
 											<ChildItems>
@@ -11569,6 +12259,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Name</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Namn</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -11578,6 +12272,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Connection name</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Anslutningsnamn</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -11595,6 +12293,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Synonym</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Synonym</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -11604,6 +12306,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Synonym for connection</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Synonym för anslutning</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -11623,6 +12329,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Client type</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Klienttyp</v8:content>
+												</v8:item>
 											</Title>
 											<ToolTip>
 												<v8:item>
@@ -11632,6 +12342,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Client type</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Klienttyp</v8:content>
 												</v8:item>
 											</ToolTip>
 											<EditMode>EnterOnInput</EditMode>
@@ -11933,6 +12647,10 @@
 																<v8:lang>ru</v8:lang>
 																<v8:content>Мобильный клиент</v8:content>
 															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Mobilklient</v8:content>
+															</v8:item>
 														</Presentation>
 														<Value xsi:type="xs:string">МобильныйКлиент</Value>
 													</xr:Value>
@@ -11949,6 +12667,10 @@
 															<v8:item>
 																<v8:lang>ru</v8:lang>
 																<v8:content>Мобильное приложение</v8:content>
+															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Mobilapp</v8:content>
 															</v8:item>
 														</Presentation>
 														<Value xsi:type="xs:string">МобильноеПриложение</Value>
@@ -11967,6 +12689,10 @@
 																<v8:lang>en</v8:lang>
 																<v8:content>Mobile client offline</v8:content>
 															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Mobilklient offline</v8:content>
+															</v8:item>
 														</Presentation>
 														<Value xsi:type="xs:string">МобильныйКлиентАвтономный</Value>
 													</xr:Value>
@@ -11983,6 +12709,10 @@
 															<v8:item>
 																<v8:lang>en</v8:lang>
 																<v8:content>Ordinary application</v8:content>
+															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Vanlig applikation</v8:content>
 															</v8:item>
 														</Presentation>
 														<Value xsi:type="xs:string">ОбычноеПриложение</Value>
@@ -12005,6 +12735,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Customer data testing group 2</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Kunddatatestgrupp 2</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="ДанныеКлиентовТестированияГруппа2РасширеннаяПодсказка" id="1352"/>
 											<ChildItems>
@@ -12019,6 +12753,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Infobase path</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sökväg till informationsbas</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -12028,6 +12766,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Path to base</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sökväg till databas</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -12045,6 +12787,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Addl. parameters</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Extra parametrar</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -12054,6 +12800,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Additional connection options</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Ytterligare anslutningsalternativ</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -12065,6 +12815,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Additional command line options connection 1C</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Ytterligare kommandoradsalternativ anslutning 1C</v8:content>
 														</v8:item>
 													</FooterText>
 													<ContextMenu name="ДанныеКлиентовТестированияДопПараметрыКонтекстноеМеню" id="1012"/>
@@ -12082,6 +12836,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Customer data testing group 3</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Kunddatatestgrupp 3</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="ДанныеКлиентовТестированияГруппа3РасширеннаяПодсказка" id="1676"/>
 											<ChildItems>
@@ -12096,6 +12854,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Computer name</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Datornamn</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -12105,6 +12867,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>The name of the computer on which the test client is running</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Namnet på datorn där testklienten körs</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -12125,6 +12891,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Port</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Port</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -12134,6 +12904,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Connection port</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Anslutningsport</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -12152,6 +12926,10 @@
 													<v8:lang>en</v8:lang>
 													<v8:content>Customer data testing group 3</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Kunddatatestgrupp 3</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="ДанныеКлиентовТестированияГруппа5РасширеннаяПодсказка" id="3214"/>
 											<ChildItems>
@@ -12165,6 +12943,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Database name in mobile application</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Databasnamn i mobilapplikation</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -12182,6 +12964,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>PID</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>PID</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -12191,6 +12977,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Test client PID</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Testklient-PID</v8:content>
 														</v8:item>
 													</ToolTip>
 													<EditMode>EnterOnInput</EditMode>
@@ -12303,6 +13093,10 @@
 											<v8:lang>en</v8:lang>
 											<v8:content>Service pages</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Servicesidor</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="СтраницыСервисРасширеннаяПодсказка" id="1360"/>
 									<ChildItems>
@@ -12315,6 +13109,10 @@
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Main settings</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Huvudinställningar</v8:content>
 												</v8:item>
 											</Title>
 											<HorizontalStretch>true</HorizontalStretch>
@@ -12334,6 +13132,10 @@
 																<v8:lang>ru</v8:lang>
 																<v8:content>Каталог фича файлов или имя одного фича файла, которые будут выполняться во время сессии тестирования.</v8:content>
 															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Katalogen med feature-filer eller namnet på en enskild feature-fil som kommer att köras under testsessionen.</v8:content>
+															</v8:item>
 														</Title>
 													</ExtendedTooltip>
 												</InputField>
@@ -12346,6 +13148,10 @@
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Filter by tags</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Filtrera efter taggar</v8:content>
 														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
@@ -12364,6 +13170,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Working with tags left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Arbeta med taggar vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -12474,6 +13284,10 @@
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Enter tags in the field. If the tag is detected in the feature, the whole feature will not be uploaded. If the tag is found in the scenario, only this scenario will not be uploaded.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Ange taggar i fältet. Om taggen hittas i funktionen laddas inte hela funktionen upp. Om taggen hittas i scenariot laddas bara detta scenario inte upp.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -12488,6 +13302,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Working with tags right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Arbeta med taggar höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -12596,6 +13414,10 @@
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Enter tags in the field. If the tag is NOT detected in the feature, the whole feature will not be uploaded. You can also upload only the feature scenarios, which contain the tags from the list.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Ange taggar i fältet. Om taggen INTE finns i funktionen laddas inte hela funktionen upp. Du kan också ladda upp bara de feature-scenarier som innehåller taggarna från listan.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -12616,6 +13438,10 @@
 															<v8:lang>en</v8:lang>
 															<v8:content>Scenario filter and feature filter</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Scenariofilter och funktionsfilter</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Behavior>Collapsible</Behavior>
@@ -12632,6 +13458,10 @@
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group selection by scenarios left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp urval efter scenarier vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -12663,6 +13493,12 @@ A script in the list is specified using its name.</v8:content>
 Сценарии будут выполняться в том порядке как они указаны в фича файле.
 Сценарий в списке указывается с помощью его имени.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Låter dig ställa in ett filter för körning av skript – endast skript från listan kommer att köras.
+Skripten körs i den ordning de anges i feature-filen.
+Ett skript i listan anges med sitt namn.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -12677,6 +13513,10 @@ A script in the list is specified using its name.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group selection by scenarios right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp urval efter scenarier höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -12709,6 +13549,15 @@ You can pass the feature name without the full path (my.feature).
 You can pass the feature name without the full path and without the file extension (my).
 The setting is applied only if feature files are loaded from the directory.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Låter dig ställa in körningsordningen för feature-filer.
+Ställer även in urvalet – endast feature-filer från listan kommer att startas.
+Du kan ange den fullständiga sökvägen till feature-filen (c:\temp\my.feature).
+Du kan ange feature-namnet utan fullständig sökväg (my.feature).
+Du kan ange feature-namnet utan fullständig sökväg och utan filändelse (my).
+Inställningen tillämpas endast om feature-filer laddas från katalogen.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -12725,6 +13574,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Feature file language</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Feature-filspråk</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -12743,6 +13596,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Gherkin generator language</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Gherkin-generatorspråk</v8:content>
 																</v8:item>
 															</Title>
 															<TitleLocation>Top</TitleLocation>
@@ -12765,6 +13622,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																			<v8:item>
 																				<v8:lang>am</v8:lang>
 																				<v8:content>ራሽኛ</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Ryska</v8:content>
 																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">ru</Value>
@@ -12791,6 +13652,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																				<v8:lang>ro</v8:lang>
 																				<v8:content>English</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>English</v8:content>
+																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">en</Value>
 																	</xr:Value>
@@ -12807,6 +13672,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Ukrainian</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Ukrainska</v8:content>
 																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">uk</Value>
@@ -12829,6 +13698,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																				<v8:lang>ro</v8:lang>
 																				<v8:content>Romana</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Rumänska</v8:content>
+																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">ro</Value>
 																	</xr:Value>
@@ -12848,6 +13721,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																			</v8:item>
 																			<v8:item>
 																				<v8:lang>ro</v8:lang>
+																				<v8:content>Deutsch</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
 																				<v8:content>Deutsch</v8:content>
 																			</v8:item>
 																		</Presentation>
@@ -12871,6 +13748,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																				<v8:lang>ro</v8:lang>
 																				<v8:content>Latvian</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Lettiska</v8:content>
+																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">lv</Value>
 																	</xr:Value>
@@ -12891,6 +13772,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																			<v8:item>
 																				<v8:lang>ro</v8:lang>
 																				<v8:content>Italian</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Italienska</v8:content>
 																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">it</Value>
@@ -12913,6 +13798,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																				<v8:lang>ro</v8:lang>
 																				<v8:content>Polish</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Polska</v8:content>
+																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">pl</Value>
 																	</xr:Value>
@@ -12934,6 +13823,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																				<v8:lang>ro</v8:lang>
 																				<v8:content>Vietnamese</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Vietnamesiska</v8:content>
+																			</v8:item>
 																		</Presentation>
 																		<Value xsi:type="xs:string">vi</Value>
 																	</xr:Value>
@@ -12953,6 +13846,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																		<v8:lang>en</v8:lang>
 																		<v8:content>The field defines scenatio generating language. If any but not Russain is selected, Known steps will contain additional columns with the step along with its description in selected language.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Fältet anger scenariogenereringsspråket. Om något annat än ryska väljs kommer kända steg att innehålla ytterligare kolumner med steget samt dess beskrivning på det valda språket.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<Events>
@@ -12971,6 +13868,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 															<v8:lang>en</v8:lang>
 															<v8:content>User actions recording</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Inspelning av användaråtgärder</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Behavior>Collapsible</Behavior>
@@ -12987,6 +13888,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>User action recording setting group left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp inställning inspelning av användaråtgärder vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -13008,6 +13913,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Add meta information when clicking</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Lägg till metainformation vid klick</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
 																	<ToolTipRepresentation>ShowRight</ToolTipRepresentation>
@@ -13023,6 +13932,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																				<v8:lang>en</v8:lang>
 																				<v8:content>If the checkbox is on, data for translation into another language will be added when clicking the scenario step by step.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad läggs data för översättning till ett annat språk till när man klickar igenom scenariot steg för steg.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -13036,6 +13949,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Generate steps that look for form elements by name</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Generera steg som söker formulärelement efter namn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
@@ -13057,6 +13974,12 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;If the flag is unchecked, then when generating the script text after being pasted, the steps in the script will search for form elements by title, if possible.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;This is possible if there is only one element with the given heading in the given form.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om flaggan är satt kommer stegen i skriptet att söka efter formulärelement med deras interna namn när skripttexten genereras efter inklistring.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om flaggan inte är markerad kommer stegen i skriptet att söka efter formulärelement efter rubrik, om möjligt, när skripttexten genereras efter inklistring.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Detta är möjligt om det bara finns ett element med den angivna rubriken i det angivna formuläret.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -13074,6 +13997,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>User action recording setting group right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp inställning inspelning av användaråtgärder höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -13097,6 +14024,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Включает показ дополнительного окошка для удобной остановки записи действий пользователя и переключения в окно Vanessa Automation. Необходимо включить использование компоненты VanessaExt.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar visningen av ett extra fönster för att bekvämt stoppa inspelningen av användaråtgärder och växla till Vanessa Automation-fönstret. Du måste aktivera användningen av VanessaExt-komponenten.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -13113,6 +14044,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>External component VanessaExt</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Extern komponent VanessaExt</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -13131,6 +14066,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group inclusion vanessa ext first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp inkludering VanessaExt första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -13146,6 +14085,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group inclusion vanessa ext first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp inkludering VanessaExt första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -13182,6 +14125,15 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- Taking a screenshot of a window and a screenshot&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;link https://github.com/lintest/VanessaExt&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;https://github.com/lintest/VanessaExt&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Avsedd för att hantera Windows- och Linux-fönster.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Möjligheter:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- Hämta en lista över fönster och en lista över processer&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- Styra fönstrets storlek och position&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- Ta en skärmbild av ett fönster och en skärmdump&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;link https://github.com/lintest/VanessaExt&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;https://github.com/lintest/VanessaExt&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -13198,6 +14150,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Component version</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Komponentversion</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ContextMenu name="ДекорацияВерсияVanessaExtКонтекстноеМеню" id="2270"/>
 																			<ExtendedTooltip name="ДекорацияВерсияVanessaExtРасширеннаяПодсказка" id="2271"/>
@@ -13213,6 +14169,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group inclusion vanessa ext first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp inkludering VanessaExt första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -13236,6 +14196,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Устанавливает признак того. что нужно использовать парсер Gherkin из компоненты VanessaExt. Этот парсер работает гораздо быстрее, чем встроенный парсер.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger flaggan att Gherkin-parsern från VanessaExt-komponenten ska användas. Denna parser är mycket snabbare än den inbyggda parsern.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -13256,6 +14220,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group inclusion vanessa ext second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp inkludering VanessaExt andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -13271,6 +14239,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group inclusion vanessa ext second row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp inkludering VanessaExt andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -13296,6 +14268,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Включает поиск файлов с помощью внешней компоненты VanessaExt.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar sökning efter filer med den externa komponenten VanessaExt.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -13310,6 +14286,10 @@ The setting is applied only if feature files are loaded from the directory.</v8:
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group inclusion vanessa ext second row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp inkludering VanessaExt andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -13336,6 +14316,12 @@ Possible return statuses:
 Возможные статусы возврата:
 &lt;link https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/ReturnStatus/ReturnStatus.md&gt;https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/ReturnStatus/ReturnStatus.md&lt;/&gt;</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om flaggan är satt och den tysta installationen av den externa komponenten misslyckas, kommer sessionen att avslutas med returkod 4.
+Möjliga returstatusar:
+&lt;link https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/ReturnStatus/ReturnStatus.md&gt;https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/ReturnStatus/ReturnStatus.md&lt;/&gt;</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -13355,6 +14341,10 @@ Possible return statuses:
 															<v8:lang>en</v8:lang>
 															<v8:content>System directories</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Systemkataloger</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Behavior>Collapsible</Behavior>
@@ -13371,6 +14361,10 @@ Possible return statuses:
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>System directories group left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Systemkataloger grupp vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -13389,6 +14383,10 @@ Possible return statuses:
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group project directory</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp projektkatalog</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -13500,6 +14498,10 @@ Possible return statuses:
 																						<v8:lang>en</v8:lang>
 																						<v8:content>The catalog with the tested project files, which are necessary for test execution.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Katalogen med de testade projektfilerna som är nödvändiga för testkörning.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -13519,6 +14521,10 @@ Possible return statuses:
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Groupe Template for New Feature</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp mall för ny funktion</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
 																	<Representation>None</Representation>
@@ -13536,6 +14542,10 @@ Possible return statuses:
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Use Template for New Feature</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Använd mall för ny funktion</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Right</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -13550,6 +14560,10 @@ Possible return statuses:
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If a template is specified (in *.txt format), then a new script will be created from it</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om en mall anges (i *.txt-format) skapas ett nytt skript från den</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -13568,6 +14582,10 @@ Possible return statuses:
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Directory of new feature template</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Katalog för ny feature-mall</v8:content>
 																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
@@ -13594,6 +14612,10 @@ Possible return statuses:
 																	<v8:lang>en</v8:lang>
 																	<v8:content>System directories group right column</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Systemkataloger grupp höger kolumn</v8:content>
+																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
 															<Representation>None</Representation>
@@ -13615,6 +14637,10 @@ Possible return statuses:
 																			<v8:lang>vi</v8:lang>
 																			<v8:content>Thư mục công cụ</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Verktygskatalog</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>Top</TitleLocation>
 																	<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -13634,6 +14660,11 @@ Possible return statuses:
 																				<v8:lang>en</v8:lang>
 																				<v8:content>The catalog of Vanessa Automation data processor. This field must be filled on the standard installation.
 When working with Vanessa Automation Single it is allowed to leave the field blank.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Katalogen för Vanessa Automations dataprocessor. Detta fält måste fyllas i vid standardinstallation.
+Vid arbete med Vanessa Automation Single är det tillåtet att lämna fältet tomt.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -13666,6 +14697,13 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 "C:\USERS%username%\APPDATA\LOCAL\TEMP".
 Настройка нужна, т.к. Vanessa Automation может создавать bat файлы для запуска системных команд, а в некоторых ОС может быть установлен запрет на запуск таких файлов из временного каталога пользователя.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Katalogen där tillfälliga skriptfiler skapas.
+Om ett inställningsvärde anges skapas tillfälliga skriptfiler i den. Om inställningsvärdet inte anges används användarens tillfälliga katalog. Vanligtvis är detta
+"C:\USERS%username%\APPDATA\LOCAL\TEMP".
+Inställningen är nödvändig eftersom Vanessa Automation kan skapa bat-filer för att köra systemkommandon, och vissa operativsystem kan förbjuda körning av sådana filer från användarens tillfälliga katalog.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -13687,6 +14725,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 															<v8:lang>en</v8:lang>
 															<v8:content>Smoke Tests</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Röktester</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -13704,6 +14746,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Smoke tests group two columns</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Röktestgrupp två kolumner</v8:content>
+																</v8:item>
 															</Title>
 															<Representation>None</Representation>
 															<ShowTitle>false</ShowTitle>
@@ -13718,6 +14764,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Smoke tests group left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Röktestgrupp vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -13736,6 +14786,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Group of smoke tests language steps</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Grupp av röktestspråksteg</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																			<Representation>None</Representation>
@@ -13750,6 +14804,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																						<v8:lang>en</v8:lang>
 																						<v8:content>The language in which feature file scripts will be generated.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Språket på vilket feature-filskript genereras.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<ChildItems>
@@ -13763,6 +14821,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Language of steps</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Stegspråk</v8:content>
 																						</v8:item>
 																					</Title>
 																					<TitleLocation>Left</TitleLocation>
@@ -13781,6 +14843,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Russian</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Ryska</v8:content>
+																									</v8:item>
 																								</Presentation>
 																								<Value xsi:type="xs:string">ru</Value>
 																							</xr:Value>
@@ -13796,6 +14862,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																									</v8:item>
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
+																										<v8:content>English</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
 																										<v8:content>English</v8:content>
 																									</v8:item>
 																								</Presentation>
@@ -13826,6 +14896,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Каталог, в который будут записаны итоговые feature-файлы.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Katalogen där de slutliga feature-filerna skrivs.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -13850,6 +14924,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>The directory in which text files with exception objects are stored. For each type of metadata object or event there must be a separate file ("Directories", "Documents", etc.).</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Katalogen där textfiler med undantagsobjekt lagras. För varje typ av metadataobjekt eller händelse måste det finnas en separat fil ("Kataloger", "Dokument" osv.).</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -13876,6 +14954,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Path to the script configuration file (the configuration file can be created on the "Script Settings" tab in the "Smoke Test Generator" window).</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Sökväg till skriptkonfigurationsfilen (konfigurationsfilen kan skapas på fliken "Skriptinställningar" i fönstret "Röktestgenerator").</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -13894,6 +14976,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Smoke tests group right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Röktestgrupp höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -13917,6 +15003,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If set, feature files in the output files directory will be deleted before tests are generated.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om satt kommer feature-filer i utdatafilkatalogen att tas bort innan testerna genereras.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -13936,6 +15026,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																						<v8:lang>en</v8:lang>
 																						<v8:content>When this flag is enabled, only objects for which there is at least one element not marked for deletion in the current infobase will participate in the generation of feature files of extended actions.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>När denna flagga är aktiverad deltar bara objekt för vilka det finns minst ett element som inte är markerat för radering i den aktuella informationsbasen i genereringen av feature-filer för utökade åtgärder.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -13954,6 +15048,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>When this flag is enabled, only objects changed relative to the provider configuration will participate in the generation of feature files. To build a report on comparing configurations, the current infobase &lt;b&gt;configurator&lt;/&gt; will be launched with the &lt;b&gt;current user&lt;/&gt; and an &lt;b&gt;empty password&lt;/&gt;.</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>När denna flagga är aktiverad kommer bara objekt som ändrats relativt leverantörskonfigurationen att delta i genereringen av feature-filer. För att bygga en rapport om konfigurationsjämförelse kommer den aktuella informationsbasens &lt;b&gt;konfigurator&lt;/&gt; att startas med den &lt;b&gt;aktuella användaren&lt;/&gt; och ett &lt;b&gt;tomt lösenord&lt;/&gt;.</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -13976,6 +15074,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																						<v8:lang>en</v8:lang>
 																						<v8:content>The name of the vendor configuration to compare configurations with.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Namnet på leverantörskonfigurationen att jämföra konfigurationer med.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -13995,6 +15097,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 															<v8:lang>en</v8:lang>
 															<v8:content>System settings</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Systeminställningar</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Behavior>Collapsible</Behavior>
@@ -14011,6 +15117,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>System settings left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Systeminställningar vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -14030,6 +15140,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Settings check boxes</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Inställningskryssrutor</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>Horizontal</Group>
 																	<Representation>None</Representation>
@@ -14045,6 +15159,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Left setting check boxes</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Vänstra inställningskryssrutor</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Group>Vertical</Group>
@@ -14252,6 +15370,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Setting checkboxes Right</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Inställningskryssrutor höger</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>Vertical</Group>
 																			<Representation>None</Representation>
@@ -14277,6 +15399,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																				<v8:lang>en</v8:lang>
 																				<v8:content>If the checkbox is on, feature file is considered as if it has @tree tag, even if it is absent. In other words, any uploaded feature file is considered as hierarchical.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad betraktas feature-filen som om den har taggen @tree, även om den saknas. Med andra ord betraktas varje uppladdad feature-fil som hierarkisk.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -14290,6 +15416,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Check Vanessa Automation in test client mode</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Kontrollera Vanessa Automation i testklientläge</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
@@ -14306,6 +15436,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Service setting. It is used in the mode when Vanessa Automation tests another session of Vanessa Automation.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Serviceinställning. Används i läget när Vanessa Automation testar en annan session av Vanessa Automation.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -14324,6 +15458,10 @@ Setting is necessary because... Vanessa Automation can create bat files to run s
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>System settings right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Systeminställningar höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
@@ -14352,6 +15490,12 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 Если используются {выражение}, то выражение будет вычисляться на клиенте.
 Если используются {!выражение}, то выражение будет вычисляться на сервере.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar läget när alla uttryck inom stegens parametrar {} utvärderas. Om avsnittet "Variabler" är deklarerat görs först ett försök att hitta en variabel från detta avsnitt med det angivna uttrycket. Annars görs ett försök att utvärdera uttrycket i {}.
+Om {expression} används utvärderas uttrycket på klienten.
+Om {!expression} används utvärderas uttrycket på servern.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -14368,6 +15512,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Other settings</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Övriga inställningar</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -14386,6 +15534,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Setting group basic other first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Inställningsgrupp grundläggande övrigt första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>NormalSeparation</Representation>
@@ -14401,6 +15553,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Setting group basic other first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Inställningsgrupp grundläggande övrigt första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -14887,6 +16043,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Allows you to control the behavior of Vanessa Automation when opening: do you need to upload a feature file with which the work was carried out in the previous session or not.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Låter dig styra beteendet hos Vanessa Automation vid öppning: om du behöver ladda upp en feature-fil som det arbetades med i föregående session eller inte.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -14901,6 +16061,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Setting group basic other first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Inställningsgrupp grundläggande övrigt första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -14926,6 +16090,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Yes</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Ja</v8:content>
+																							</v8:item>
 																						</Presentation>
 																						<Value xsi:type="xs:string">Да</Value>
 																					</xr:Value>
@@ -14942,6 +16110,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>No</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Nej</v8:content>
 																							</v8:item>
 																						</Presentation>
 																						<Value xsi:type="xs:string">Нет</Value>
@@ -14960,6 +16132,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Allows Vanessa Automation behavior management on shoutdown: is it necessary to show the dialog of main form closure confirmation.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Hanterar beteendet hos Vanessa Automation vid avstängning: om det är nödvändigt att visa dialogrutan för bekräftelse av stängning av huvudformuläret.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -14977,6 +16153,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Setting group basic other second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Inställningsgrupp grundläggande övrigt andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>NormalSeparation</Representation>
@@ -14992,6 +16172,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Setting group basic other second row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Inställningsgrupp grundläggande övrigt andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -15010,6 +16194,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Custom setting provider</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Anpassad inställningsleverantör</v8:content>
 																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
@@ -15033,6 +16221,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																								<v8:lang>ro</v8:lang>
 																								<v8:content>CONSUL</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>CONSUL</v8:content>
+																							</v8:item>
 																						</Presentation>
 																						<Value xsi:type="xs:string">CONSUL</Value>
 																					</xr:Value>
@@ -15052,6 +16244,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																							</v8:item>
 																							<v8:item>
 																								<v8:lang>ro</v8:lang>
+																								<v8:content>FILE</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
 																								<v8:content>FILE</v8:content>
 																							</v8:item>
 																						</Presentation>
@@ -15084,6 +16280,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Custom settings provider</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Leverantör av anpassade inställningar</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -15100,6 +16300,10 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Address of custom settings</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Adress för anpassade inställningar</v8:content>
 																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
@@ -15121,6 +16325,12 @@ If {!expression} Is used, the expression will be evaluated on the server.</v8:co
 As a result of reading the settings file, global variables will be created.
 When running tests from the command line, to create variables, you need to pass them in the main settings json file in the "GlobalVars" parameter, which is an array of Key:Value values.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Filsökvägen eller URL:en där inställningarna finns. Som standard projektkatalogen (standardfilnamn är user_settings.json) eller localhost.
+Som ett resultat av att läsa inställningsfilen skapas globala variabler.
+Vid körning av tester från kommandoraden, för att skapa variabler, behöver du skicka dem i huvudinställningens json-fil i parametern "GlobalVars", som är en array av Key:Value-värden.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -15135,6 +16345,10 @@ When running tests from the command line, to create variables, you need to pass 
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Setting group basic other second row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Inställningsgrupp grundläggande övrigt andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -15158,6 +16372,10 @@ When running tests from the command line, to create variables, you need to pass 
 																						<v8:lang>en</v8:lang>
 																						<v8:content>This field contains a text editor to open a feature file and position on the current line when clicking "Open .feature file in editor".</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Detta fält innehåller en textredigerare för att öppna en feature-fil och positionera på aktuell rad vid klick på "Öppna .feature-fil i redigeraren".</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -15180,6 +16398,10 @@ When running tests from the command line, to create variables, you need to pass 
 															<v8:lang>en</v8:lang>
 															<v8:content>Reset settings</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Återställ inställningar</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Behavior>Collapsible</Behavior>
@@ -15196,6 +16418,10 @@ When running tests from the command line, to create variables, you need to pass 
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group reset left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp återställning vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -15219,6 +16445,10 @@ When running tests from the command line, to create variables, you need to pass 
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Clears known steps cash. After command execution close Vanessa Automation and reopen it. </v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Rensar cachen för kända steg. Stäng Vanessa Automation och öppna det igen efter att kommandot har körts. </v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</Button>
@@ -15233,6 +16463,10 @@ When running tests from the command line, to create variables, you need to pass 
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Reset group right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Återställningsgrupp höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -15254,6 +16488,10 @@ When running tests from the command line, to create variables, you need to pass 
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Выполняет сброс настроек на значения настроек по умолчанию.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Återställer inställningarna till standardvärden.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</Button>
@@ -15273,6 +16511,10 @@ When running tests from the command line, to create variables, you need to pass 
 													<v8:lang>en</v8:lang>
 													<v8:content>Test client settings</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Testklientinställningar</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаКлиентыТестированияРасширеннаяПодсказка" id="1839"/>
 											<ChildItems>
@@ -15285,6 +16527,10 @@ When running tests from the command line, to create variables, you need to pass 
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Test client launch</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Testklientstart</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -15303,6 +16549,10 @@ When running tests from the command line, to create variables, you need to pass 
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Start test client group first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp starta testklient första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>NormalSeparation</Representation>
@@ -15318,6 +16568,10 @@ When running tests from the command line, to create variables, you need to pass 
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -15344,6 +16598,10 @@ When running tests from the command line, to create variables, you need to pass 
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If the option is on, TestClient will launch in full-screen mode.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om alternativet är aktiverat startar TestClient i helskärmsläge.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -15358,6 +16616,10 @@ When running tests from the command line, to create variables, you need to pass 
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -15382,6 +16644,10 @@ When running tests from the command line, to create variables, you need to pass 
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Если опция включена, то модальное окно при запуске клиента тестирования означает ошибку подключения клиента тестирования.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat innebär det modala fönstret vid start av testklienten ett testklientanslutningsfel.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -15399,6 +16665,10 @@ When running tests from the command line, to create variables, you need to pass 
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Test client startup group second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Testklientstartgrupp andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>NormalSeparation</Representation>
@@ -15414,6 +16684,10 @@ When running tests from the command line, to create variables, you need to pass 
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group second row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -15440,6 +16714,10 @@ When running tests from the command line, to create variables, you need to pass 
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Включает повторный запуск процесса клиента тестирования, если предыдущий запуск не сработал (например, если не была получена лицензия). Только для толстого и тонкого клиента.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar omstart av testklientprocessen om den föregående körningen inte fungerade (till exempel om ingen licens erhölls). Endast för tjock och tunn klient.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -15457,6 +16735,10 @@ When running tests from the command line, to create variables, you need to pass 
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group second row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -15485,6 +16767,12 @@ This issue is relevant when running tests on Linux.</v8:content>
 Это нужно. т.к. клиент тестирования может поменять порт, на котором он запустился, несмотря на переданные параметры.
 Эта проблема актуальна при запуске тестов в Linux.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat görs vid anslutning av testklienten ett försök att bestämma den verkliga porten på vilken testklienten startades.
+Det är nödvändigt eftersom testklienten kan ändra porten på vilken den startade, trots de skickade parametrarna.
+Detta problem är relevant vid körning av tester på Linux.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -15502,6 +16790,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Test client startup group third line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Testklientstartgrupp tredje raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -15517,6 +16809,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group third row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp tredje raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -15544,6 +16840,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Задаёт интервал, с которым будет производиться попытка запустить сеанс клиента тестирования.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger intervallet med vilket ett försök att starta en testklientsession görs.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -15558,6 +16858,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group third row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp tredje raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -15584,6 +16888,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Specifies timeout in seconds of Vanessa Automation awaiting for TestClient launch. After timeout the exception will be risen.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger timeout i sekunder för Vanessa Automations väntan på TestClient-start. Efter timeout kastas ett undantag.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -15601,6 +16909,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Test client launch group fourth line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Testklientstartgrupp fjärde raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -15616,6 +16928,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group fourth row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp fjärde raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -15642,6 +16958,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Specifies ports range to search for free port to run TestClient. For example 48100-48200.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger portintervall för att söka efter ledig port för att köra TestClient. Till exempel 48100-48200.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -15656,6 +16976,10 @@ This issue is relevant when running tests on Linux.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group fourth row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp fjärde raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -15679,6 +17003,11 @@ The file name will be generated according to the rule TestingClientName+LaunchDa
 																						<v8:content>Если параметр задан, то при запуске клиента тестирования будет добавляться параметр /Out &lt;ИмяФайла&gt;.
 Имя файла будет генерироваться по правилу ИмяКлиентаТестирования+ДатаВремяЗапуска.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om parametern är satt läggs parametern /Out &lt;FileName&gt; till när testklienten startas.
+Filnamnet genereras enligt regeln TestingClientName+LaunchDateTime.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -15696,6 +17025,10 @@ The file name will be generated according to the rule TestingClientName+LaunchDa
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Test client launch group fifth line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Testklientstartgrupp femte raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -15711,6 +17044,10 @@ The file name will be generated according to the rule TestingClientName+LaunchDa
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group fifth row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp femte raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -15735,6 +17072,10 @@ The file name will be generated according to the rule TestingClientName+LaunchDa
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>В поле указываются дополнительные ключи запуска клиента тестирования, которые будут передаваться запускаемому сеансу 1С</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Fältet anger ytterligare nycklar för start av testklienten, som kommer att överföras till den startade 1C-sessionen.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -15749,6 +17090,10 @@ The file name will be generated according to the rule TestingClientName+LaunchDa
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group fifth row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp femte raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -15773,6 +17118,11 @@ This can be useful if the computers on which the tests are run have a limited am
 																						<v8:content>Если опция включена, то будет включен контроль, что одновременно не может быть подключено более одного клиента тестирования.
 Это может быть полезно, если на компьютерах, на которых запускаются тесты, ограничен объем оперативной памяти и нужно контролировать запуск лишних процессов.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat aktiveras kontroll att mer än en testklient inte kan anslutas samtidigt.
+Detta kan vara användbart om datorerna där testerna körs har en begränsad mängd RAM och du behöver kontrollera starten av onödiga processer.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -15790,6 +17140,10 @@ This can be useful if the computers on which the tests are run have a limited am
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Test client startup group sixth line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Testklientstartgrupp sjätte raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -15805,6 +17159,10 @@ This can be useful if the computers on which the tests are run have a limited am
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group sixth row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp sjätte raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -15830,6 +17188,10 @@ This can be useful if the computers on which the tests are run have a limited am
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If this option is enabled, scheduled jobs execution will be disabled when new test client will start for a file infobase. Uses command line key /AllowExecuteScheduledJobs -Off</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat inaktiveras körningen av schemalagda jobb när en ny testklient startas för en filinformationsbas. Använder kommandoradsnyckeln /AllowExecuteScheduledJobs -Off</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -15844,6 +17206,10 @@ This can be useful if the computers on which the tests are run have a limited am
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test client launch group sixth row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Testklientstartgrupp sjätte raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -15871,6 +17237,13 @@ If such messages were found, a script error will be raised.
 При завершении работы теста проверяет в окне "Информация для технической поддержки" наличие специальных сообщений о контекстных серверных вызовах.
 Если такие сообщения были найдены, то будет вызвана ошибка сценария.
 &lt;link https://its.1c.ru/db/pubv8devui/content/282/1&gt;Подробная информация тут&lt;/&gt;</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Lägger till strängen /EnableCheckServerCalls till startparametrarna för testklienter.
+När testet är klart kontrolleras fönstret ”Teknisk supportinformation” för speciella meddelanden om kontextserveranrop.
+Om sådana meddelanden hittas kommer ett skriptfel att uppstå.
+&lt;link https://its.1c.ru/db/pubv8devui/content/282/1&gt;Detaljerad information här&lt;/&gt;</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -15987,6 +17360,10 @@ If such messages were found, a script error will be raised.
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Run test client in debug mode</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Kör testklient i felsökningsläge</v8:content>
+																</v8:item>
 															</Title>
 															<TitleLocation>Right</TitleLocation>
 															<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -16002,6 +17379,10 @@ If such messages were found, a script error will be raised.
 																	<v8:item>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>If the check box is selected, TestClient will be launched with /debug and /debuggerURL startup keys.</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Om kryssrutan är markerad startas TestClient med startnycklar /debug och /debuggerURL.</v8:content>
 																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
@@ -16019,6 +17400,10 @@ If such messages were found, a script error will be raised.
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Debugger settings</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Felsökningsinställningar</v8:content>
+																</v8:item>
 															</Title>
 															<ToolTip>
 																<v8:item>
@@ -16028,6 +17413,10 @@ If such messages were found, a script error will be raised.
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group debugger settings</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp felsökningsinställningar</v8:content>
 																</v8:item>
 															</ToolTip>
 															<Group>Vertical</Group>
@@ -16046,6 +17435,10 @@ If such messages were found, a script error will be raised.
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Debugger address</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Debuggeradress</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>Top</TitleLocation>
 																	<ToolTip>
@@ -16059,6 +17452,10 @@ If such messages were found, a script error will be raised.
 																		</v8:item>
 																		<v8:item>
 																			<v8:lang>ro</v8:lang>
+																			<v8:content>http://localhost:1560</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
 																			<v8:content>http://localhost:1560</v8:content>
 																		</v8:item>
 																	</ToolTip>
@@ -16075,6 +17472,10 @@ If such messages were found, a script error will be raised.
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Address of debugger to be passed to TestClient.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Debuggeradress som ska skickas till TestClient.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -16088,6 +17489,10 @@ If such messages were found, a script error will be raised.
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Debug keys</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Felsökningsnycklar</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Top</TitleLocation>
@@ -16104,6 +17509,10 @@ If such messages were found, a script error will be raised.
 																			<v8:lang>ro</v8:lang>
 																			<v8:content>-http -attach</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>-http -attach</v8:content>
+																		</v8:item>
 																	</ToolTip>
 																	<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																	<ContextMenu name="КлючиОтладкиКонтекстноеМеню" id="862"/>
@@ -16117,6 +17526,10 @@ If such messages were found, a script error will be raised.
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Launch parameters to be passed to TestClient.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Startparametrar som ska skickas till TestClient.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -16135,6 +17548,10 @@ If such messages were found, a script error will be raised.
 															<v8:lang>en</v8:lang>
 															<v8:content>Browser launch</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Webbläsarstart</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -16144,6 +17561,10 @@ If such messages were found, a script error will be raised.
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Browser launch settings</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Inställningar för webbläsarstart</v8:content>
 														</v8:item>
 													</ToolTip>
 													<Group>Vertical</Group>
@@ -16162,6 +17583,10 @@ If such messages were found, a script error will be raised.
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Browser launch string installation command group</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Webbläsarstartstränginstallationskommandogrupp</v8:content>
+																</v8:item>
 															</Title>
 															<ToolTip>
 																<v8:item>
@@ -16171,6 +17596,10 @@ If such messages were found, a script error will be raised.
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Browser launch string installation command group</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Webbläsarstartstränginstallationskommandogrupp</v8:content>
 																</v8:item>
 															</ToolTip>
 															<Group>Horizontal</Group>
@@ -16208,6 +17637,11 @@ If such messages were found, a script error will be raised.
 																		<v8:content>This field indicates the command to launch the browser. If the field is empty, then the default browser will be used to start the web client.
 If there is a TestClientUrl string in the browser launch command, then it will be replaced with the test client connection string. Otherwise, the test client connection string will be appended to the end as the last parameter.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Detta fält anger kommandot för att starta webbläsaren. Om fältet är tomt används standardwebbläsaren för att starta webbklienten.
+Om det finns en TestClientUrl-sträng i kommandot för webbläsarstart ersätts den med testklientens anslutningssträng. Annars läggs testklientens anslutningssträng till i slutet som den sista parametern.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 														</InputField>
@@ -16221,6 +17655,10 @@ If there is a TestClientUrl string in the browser launch command, then it will b
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Use browser +  web socket</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Använd webbläsare + websocket</v8:content>
 																</v8:item>
 															</Title>
 															<TitleLocation>Right</TitleLocation>
@@ -16240,6 +17678,11 @@ If there is a TestClientUrl string in the browser launch command, then it will b
 																		<v8:content>Allows to execute external commands in the browser using WebSocket.
 For the option to work, you must enable the use of the VanessaExt component.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Tillåter att köra externa kommandon i webbläsaren via WebSocket.
+För att alternativet ska fungera måste du aktivera användningen av VanessaExt-komponenten.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 														</CheckBoxField>
@@ -16254,6 +17697,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Closing test client</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Stängning av testklient</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -16271,6 +17718,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Test client closing group left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Testklientstängningsgrupp vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -16297,6 +17748,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Если флаг установлен, то при закрытии клиента тестирования будет проверяться, закрылся ли клиент тестирования по его PID. Если клиент тестирования не закрылся штатно, то будет выполнена попытка закрыть его с помощью команды ОС.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om flaggan är satt kontrolleras vid stängning av testklienten om testklienten har stängts via sitt PID. Om testklienten inte har stängts normalt görs ett försök att stänga den med OS-kommandot.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -16320,6 +17775,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Количество секунд, в течение которого будет проверяться, что процесс клиента тестирования завершился самостоятельно.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Antalet sekunder för att kontrollera att testklientprocessen avslutades på egen hand.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -16334,6 +17793,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Test client closing group right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Testklientstängningsgrupp höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -16351,6 +17814,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Mobile client</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Mobilklient</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -16374,6 +17841,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																	<v8:item>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>The path to the adb program file</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Sökvägen till adb-programfilen</v8:content>
 																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
@@ -16407,6 +17878,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 													<v8:lang>en</v8:lang>
 													<v8:content>Running scenarios</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Körning av scenarier</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаВыполнениеСценариевРасширеннаяПодсказка" id="1841"/>
 											<ChildItems>
@@ -16419,6 +17894,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Logging and notification</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Loggning och notifiering</v8:content>
 														</v8:item>
 													</Title>
 													<Behavior>Collapsible</Behavior>
@@ -16435,6 +17914,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Script execution group logging left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Skriptkörningsgrupp loggning vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -16454,6 +17937,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Output verbose log and debug log</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Mata ut detaljerad logg och felsökningslogg</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
@@ -16476,6 +17963,13 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 1. Step beginning notification.
 2. Test clients connection notification.
 3. Other information.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Hantering av meddelandeutmatning. Om kryssrutan är aktiverad innehåller användarmeddelanden ytterligare information om scenariets framsteg, såsom:
+1. Stegstartnotifiering.
+2. Notifiering om testklientanslutning.
+3. Övrig information.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -16583,6 +18077,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:lang>en</v8:lang>
 																				<v8:content>If the checkbox is on, scenario and steps beginning events will be written to the event log.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad skrivs scenario- och stegstarthändelser till händelseloggen.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -16597,6 +18095,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Script execution logging group right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Skriptkörningsloggningsgrupp höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
@@ -16631,6 +18133,15 @@ This option only works under Windows.</v8:content>
 Необходимо включить использование компоненты VanessaExt.
 Опция работает только под Windows.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om detta alternativ är aktiverat ges följande ljudnotifiering vid slutet av skriptkörningen:
+1. Skripten slutfördes framgångsrikt.
+2. Ett fel uppstod vid körning av skriptet.
+3. Brytpunkten utlöstes.
+Du måste aktivera användningen av VanessaExt-tillägget.
+Detta alternativ fungerar bara under Windows.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -16647,6 +18158,10 @@ This option only works under Windows.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Script execution speed</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Skriptkörningshastighet</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -16665,6 +18180,10 @@ This option only works under Windows.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Invoke steps as async procedure</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Anropa steg som asynkron procedur</v8:content>
 																</v8:item>
 															</Title>
 															<TitleLocation>Right</TitleLocation>
@@ -16773,6 +18292,12 @@ This option only works under Windows.</v8:content>
 																		<v8:content>If the checkbox is on, each step will be executed asynchronously with the specified delay.
 If the checkbox is off, the steps will be executed synchronously. Steps tree will be updated on each 100th step.
 Scenario runs several times faster when the flag is off.</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Om kryssrutan är aktiverad körs varje steg asynkront med den angivna fördröjningen.
+Om kryssrutan är inaktiverad körs stegen synkront. Stegträdet uppdateras vid varje 100:e steg.
+Scenariot körs flera gånger snabbare när flaggan är inaktiverad.</v8:content>
 																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
@@ -16886,6 +18411,10 @@ Scenario runs several times faster when the flag is off.</v8:content>
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Specifies delay between steps in asynchronous mode.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Anger fördröjning mellan steg i asynkront läge.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 														</InputField>
@@ -16900,6 +18429,10 @@ Scenario runs several times faster when the flag is off.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>When an error occurs</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vid fel</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -17015,6 +18548,11 @@ Scenario runs several times faster when the flag is off.</v8:content>
 																		<v8:content>If the checkbox is on, scenario will be executed until the first error occurs.
 All the following scenarios will be skipped.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Om kryssrutan är aktiverad körs scenariot till det första felet uppstår.
+Alla efterföljande scenarier hoppas över.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 														</CheckBoxField>
@@ -17039,6 +18577,11 @@ All the following scenarios will be skipped.</v8:content>
 																		<v8:content>If flag is set, when an error occurs in tree steps will be shown column with the row number in the tree, if this column was hidden.
 Actual when working in the step tree mode.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Om flaggan är satt visas vid ett fel i trädsteget kolumnen med radnumret i trädet, om denna kolumn var dold.
+Aktuellt vid arbete i stegträdläge.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 														</CheckBoxField>
@@ -17053,6 +18596,10 @@ Actual when working in the step tree mode.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Stop script execution</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Stoppa skriptkörning</v8:content>
 														</v8:item>
 													</Title>
 													<Behavior>Collapsible</Behavior>
@@ -17070,6 +18617,10 @@ Actual when working in the step tree mode.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group stop script execution first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp stoppa skriptkörning första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -17085,6 +18636,10 @@ Actual when working in the step tree mode.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group stop script execution first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp stoppa skriptkörning första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -17112,6 +18667,10 @@ Actual when working in the step tree mode.</v8:content>
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Включает показ дополнительного окна, которое позволяет остановить выполнение сценария. Необходимо включить использование компоненты VanessaExt.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar visningen av ett extra fönster som gör det möjligt att stoppa körningen av skriptet. Du måste aktivera användningen av VanessaExt-komponenten.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -17126,6 +18685,10 @@ Actual when working in the step tree mode.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group stop script execution first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp stoppa skriptkörning första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -17148,6 +18711,10 @@ Actual when working in the step tree mode.</v8:content>
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Если опция включена, то при нажатии кнопки остановки выполнения сценария в специальном окошке будет создаваться временный файл, а Vanessa Automation будет останавливать выполнение работы сценария, проверяя наличие этого файла.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat skapas en temporär fil när du klickar på knappen för att stoppa skriptkörning i ett specialfönster, och Vanessa Automation stoppar skriptkörningen genom att kontrollera om denna fil finns.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -17167,6 +18734,10 @@ Actual when working in the step tree mode.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Update of script execution statistics</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Uppdatering av skriptkörningsstatistik</v8:content>
+														</v8:item>
 													</Title>
 													<Behavior>Collapsible</Behavior>
 													<Collapsed>true</Collapsed>
@@ -17182,6 +18753,10 @@ Actual when working in the step tree mode.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group group update statistics left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp uppdateringsstatistik vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -17207,6 +18782,10 @@ Actual when working in the step tree mode.</v8:content>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>If the flag is set, then statistics are updated during script execution: how many script steps have passed, how many scripts have crashed, and so on.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om flaggan är satt uppdateras statistiken under skriptkörningen: hur många skriptsteg som har passerat, hur många skript som har kraschat och så vidare.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -17223,6 +18802,10 @@ Actual when working in the step tree mode.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Test execution stabilization</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Stabilisering av testkörning</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -17241,6 +18824,10 @@ Actual when working in the step tree mode.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group subsystem stabilization of test execution zero line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp undersystem stabilisering av testkörning nollte raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -17256,6 +18843,10 @@ Actual when working in the step tree mode.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group subsystem stabilization of test execution zero line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp undersystem stabilisering av testkörning nollte raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -17279,6 +18870,10 @@ Actual when working in the step tree mode.</v8:content>
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Если в настройке указано значение более одного, тогда если сценарий не был выполнен успешно, будет выполнено ещё несколько попыток выполнения сценария.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om inställningen anger ett värde större än ett görs, om skriptet inte kördes framgångsrikt, flera ytterligare försök att köra skriptet.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -17293,6 +18888,10 @@ Actual when working in the step tree mode.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Test execution stabilization subsystem group first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Undersystem stabilisering av testkörning grupp första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -17328,6 +18927,16 @@ For this option to work, the VAExtension extension must be installed in the test
    ```
 Для работы опции в базе клиента тестирования должно быть установлено расширение VAExtension.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Det finns ett problem att texten som användaren för närvarande redigerar kan skrivas över vid synkronisering av formulärets tillstånd efter att serveranropet har slutförts.
+I tester kan detta visa sig genom att testet matade in ett värde i ett fält, men innan det började arbeta med ett annat fält återställdes detta värde till sitt tidigare tillstånd.
+Detta alternativ aktiverar en mekanism där egenskapen "EditTextUpdate" för formulärfält ändras efter anrop av steget
+   ```Gherkin
+   Then "WindowTitle" window is opened
+   ```
+För att detta alternativ ska fungera måste tillägget VAExtension vara installerat i testklientdatabasen.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -17345,6 +18954,10 @@ For this option to work, the VAExtension extension must be installed in the test
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group subsystem test execution stabilization first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp undersystem stabilisering av testkörning första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -17360,6 +18973,10 @@ For this option to work, the VAExtension extension must be installed in the test
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group subsystem test execution stabilization first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp undersystem stabilisering av testkörning första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -17388,6 +19005,11 @@ For this option to work, the VAExtension extension must be installed in the test
 																						<v8:content>Sets maximum tries number for multiple steps.
 Increasing this parameter may make scenarios execution more stable on the weak hardware.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger maximalt antal försök för flera steg.
+Att öka denna parameter kan göra scenariokörningen mer stabil på svag hårdvara.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -17402,6 +19024,10 @@ Increasing this parameter may make scenarios execution more stable on the weak h
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group subsystem test execution stabilization first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp undersystem stabilisering av testkörning första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -17431,6 +19057,13 @@ Increasing this parameter may make scenarios execution more stable on the weak h
    Then "WindowTitle" window is opened
    ```</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Maximal tid för att söka efter ett fönster i ett steg
+   ```Gherkin
+   Then "WindowTitle" window is opened
+   ```</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -17448,6 +19081,10 @@ Increasing this parameter may make scenarios execution more stable on the weak h
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group subsystem test execution stabilization second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp undersystem stabilisering av testkörning andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -17463,6 +19100,10 @@ Increasing this parameter may make scenarios execution more stable on the weak h
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group subsystem test execution stabilization second row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp undersystem stabilisering av testkörning andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -17499,6 +19140,15 @@ For example, if the parameter value is set to 20 seconds and the step is used
    ```
 then in reality the maximum step time will be 20 seconds, not 10.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger den maximala tiden att vänta på ett asynkront steg.
+Till exempel, om parametervärdet är satt till 20 sekunder och steget används
+   ```Gherkin
+   And I wait the field named "FieldName" will be filled in 10 seconds
+   ```
+då blir den maximala stegtiden i verkligheten 20 sekunder, inte 10.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -17513,6 +19163,10 @@ then in reality the maximum step time will be 20 seconds, not 10.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group subsystem test execution stabilization second row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp undersystem stabilisering av testkörning andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -17547,6 +19201,15 @@ And I wait "WindowTitle" window opening in 60 seconds
 And I wait the window with header different from "WindowTitle" opening in 60 seconds
 ```</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Ytterligare pausvärde som alltid kommer att tillämpas i ett steg
+```Gherkin
+Then "WindowTitle" window is opened
+And I wait "WindowTitle" window opening in 60 seconds
+And I wait the window with header different from "WindowTitle" opening in 60 seconds
+```</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -17564,6 +19227,10 @@ And I wait the window with header different from "WindowTitle" opening in 60 sec
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group subsystem stabilization of test execution third line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp undersystem stabilisering av testkörning tredje raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -17579,6 +19246,10 @@ And I wait the window with header different from "WindowTitle" opening in 60 sec
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group subsystem test execution stabilization third row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp undersystem stabilisering av testkörning tredje raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -17606,6 +19277,12 @@ And I wait the window with header different from "WindowTitle" opening in 60 sec
 If the specified time is exceeded, the exception "The maximum execution time of the action on the testing client side has been exceeded" is generated. In this case, the action will continue.
 If the parameter is 0, commands wait until the end of execution without checking the elapsed time since the start of execution.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger den maximala körningstiden för åtgärder som returnerar ett värde till testhanteraren.
+Om den angivna tiden överskrids genereras undantaget "Den maximala körningstiden för åtgärden på testklientsidan har överskridits". I detta fall fortsätter åtgärden.
+Om parametern är 0 väntar kommandon tills körningen är klar utan att kontrollera förfluten tid sedan starten av körningen.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -17620,6 +19297,10 @@ If the parameter is 0, commands wait until the end of execution without checking
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group subsystem test execution stabilization third row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp undersystem stabilisering av testkörning tredje raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -17646,6 +19327,11 @@ If the parameter is 0, commands wait until the end of execution without checking
 																						<v8:content>Adds delay for multiple actions, which may cause unstable scenario execution, e.g.: move to line, field value check etc.
 This option slow the execution down .</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Lägger till fördröjning för flera åtgärder, vilket kan orsaka instabil scenariokörning, t.ex.: flytta till rad, fältvärdecheck osv.
+Detta alternativ saktar ner körningen.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -17668,6 +19354,10 @@ This option slow the execution down .</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Updating data in a tree in steps</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Uppdatering av data i ett träd i steg</v8:content>
+														</v8:item>
 													</Title>
 													<Behavior>Collapsible</Behavior>
 													<Collapsed>true</Collapsed>
@@ -17683,6 +19373,10 @@ This option slow the execution down .</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group data update in the tree left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp datauppdatering i trädet vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -17710,6 +19404,11 @@ This option slow the execution down .</v8:content>
 																				<v8:content>If the checkbox is on, current row of the tree will be active on step execution. It is recomended to turn the checkbox off on CI server to fasten up.
 Actual when working in the step tree mode.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad är den aktuella raden i trädet aktiv vid stegkörning. Det rekommenderas att inaktivera kryssrutan på CI-servern för att snabba upp.
+Aktuellt vid arbete i stegträdläge.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -17727,6 +19426,10 @@ Actual when working in the step tree mode.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Script statuses</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Skriptstatusar</v8:content>
+														</v8:item>
 													</Title>
 													<Behavior>Collapsible</Behavior>
 													<Collapsed>true</Collapsed>
@@ -17742,6 +19445,10 @@ Actual when working in the step tree mode.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Script execution group statuses left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Skriptkörningsgrupp statusar vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -17769,6 +19476,11 @@ Actual when working in the step tree mode.</v8:content>
 																				<v8:content>If the checkbox is on, pending steps will set assembly status to failed on the execution on CI server.
 It is recommended to set this checkbox on.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad sätter väntande steg byggstatusen till misslyckad vid körning på CI-server.
+Det rekommenderas att aktivera denna kryssruta.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -17783,6 +19495,10 @@ It is recommended to set this checkbox on.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Script execution status group right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Skriptkörningsstatusgrupp höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -17806,6 +19522,10 @@ It is recommended to set this checkbox on.</v8:content>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>If the checkbox is on, assembly status will be set to Failed only if failing step starts with Then keyword. In all other cases - Broken. This helps distinguish broken tests from real configuration errors.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad sätts byggstatusen till Failed bara om det felande steget börjar med nyckelordet Then. I alla andra fall – Broken. Detta hjälper till att skilja trasiga tester från verkliga konfigurationsfel.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -17822,6 +19542,10 @@ It is recommended to set this checkbox on.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Other script execution settings</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Övriga inställningar för skriptkörning</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
@@ -17840,6 +19564,10 @@ It is recommended to set this checkbox on.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Script execution group other first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Skriptkörningsgrupp övrigt första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -17855,6 +19583,10 @@ It is recommended to set this checkbox on.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Script execution group other first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Skriptkörningsgrupp övrigt första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -17880,6 +19612,10 @@ It is recommended to set this checkbox on.</v8:content>
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Если опция включена, тогда вызов метода Sleep() будет происходить через вызов команды Ping. Это нужно в том случае, если в окне клиента тестирования в данный момент не отвечает на запросы.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat anropas metoden Sleep() genom ett anrop till Ping-kommandot. Detta är nödvändigt om testklientfönstret för närvarande inte svarar på förfrågningar.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -17894,6 +19630,10 @@ It is recommended to set this checkbox on.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Script execution group other first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Skriptkörningsgrupp övrigt första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -17918,6 +19658,11 @@ It is recommended to set this checkbox on.</v8:content>
 																						<v8:content>If the checkbox is on, pending steps will set assembly status to failed on the execution on CI server.
 It is recommended to set this checkbox on.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om kryssrutan är aktiverad sätter väntande steg byggstatusen till misslyckad vid körning på CI-server.
+Det rekommenderas att aktivera denna kryssruta.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -17935,6 +19680,10 @@ It is recommended to set this checkbox on.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Script execution group other second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Skriptkörningsgrupp övrigt andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -17950,6 +19699,10 @@ It is recommended to set this checkbox on.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Script execution group other second row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Skriptkörningsgrupp övrigt andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -17978,6 +19731,11 @@ An update attempt will occur if there are several attempts to get the table valu
 Попытка обновления будет происходить в том случае, если происходит несколько попыток получения значения таблицы и первая попытка была неуспешной.
 </v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat försöker testet vid mottagning av en tabell hitta och klicka på tabellknappen "Uppdatera" och trycka på den.
+Ett uppdateringsförsök sker om det finns flera försök att hämta tabellvärdet och det första försöket var misslyckades.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -17992,6 +19750,10 @@ An update attempt will occur if there are several attempts to get the table valu
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Script execution group other second row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Skriptkörningsgrupp övrigt andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -18017,6 +19779,11 @@ Allows you to receive the entire layout with the design in the web client.</v8:c
 																						<v8:content>Включает получение значений макетов (печатных форм и отчетов)  с помощью расширения VAExtension.
 Позволяет получать макет целиком с оформлением в web клиенте.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar hämtning av layoutvärden (utskriftsbara formulär och rapporter) med VAExtension.
+Låter dig ta emot hela layouten med designen i webbklienten.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -18038,6 +19805,10 @@ Allows you to receive the entire layout with the design in the web client.</v8:c
 													<v8:lang>en</v8:lang>
 													<v8:content>Screenshots</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Skärmbilder</v8:content>
+												</v8:item>
 											</Title>
 											<ToolTip>
 												<v8:item>
@@ -18047,6 +19818,10 @@ Allows you to receive the entire layout with the design in the web client.</v8:c
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Screenshots page</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Sida skärmbilder</v8:content>
 												</v8:item>
 											</ToolTip>
 											<ExtendedTooltip name="СтраницаСкриншотыРасширеннаяПодсказка" id="2276"/>
@@ -18060,6 +19835,10 @@ Allows you to receive the entire layout with the design in the web client.</v8:c
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Page screenshots first line</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sida skärmbilder första raden</v8:content>
 														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
@@ -18075,6 +19854,10 @@ Allows you to receive the entire layout with the design in the web client.</v8:c
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page screenshots first row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder första raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -18188,6 +19971,11 @@ Allows you to receive the entire layout with the design in the web client.</v8:c
 																				<v8:content>Enables taking screenshots in case of an error or on demand (the @screenshot tag is specified before the step).
 To enable the option, make sure the "Screenshot creation command" field is filled in or VanessaExt is enabled.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar skärmbilder vid fel eller på begäran (taggen @screenshot anges före steget).
+För att aktivera alternativet, se till att fältet "Kommando för skärmbildsskapande" är ifyllt eller att VanessaExt är aktiverat.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -18206,6 +19994,10 @@ To enable the option, make sure the "Screenshot creation command" field is fille
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page screenshots first row right column</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder första raden höger kolumn</v8:content>
+																</v8:item>
 															</Title>
 															<Representation>None</Representation>
 															<ShowTitle>false</ShowTitle>
@@ -18221,6 +20013,10 @@ To enable the option, make sure the "Screenshot creation command" field is fille
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Take a screenshot of each 1C session (process)</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Ta en skärmbild av varje 1C-session (process)</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
@@ -18240,6 +20036,11 @@ To enable the option, make sure the "Screenshot creation command" field is fille
 																				<v8:content>Enables taking screenshots for each 1C window when an error occurs.
 SikuliX or VanessaExt (recommended) is used for this option.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar skärmbilder för varje 1C-fönster när ett fel uppstår.
+SikuliX eller VanessaExt (rekommenderat) används för detta alternativ.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -18257,6 +20058,10 @@ SikuliX or VanessaExt (recommended) is used for this option.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Page screenshots second line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sida skärmbilder andra raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>NormalSeparation</Representation>
@@ -18272,6 +20077,10 @@ SikuliX or VanessaExt (recommended) is used for this option.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page screenshots second row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder andra raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -18291,6 +20100,10 @@ SikuliX or VanessaExt (recommended) is used for this option.</v8:content>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>VanessaExt add-in screenshots</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>VanessaExt-tillägg skärmbilder</v8:content>
+																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
 																	<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -18309,6 +20122,11 @@ SikuliX or VanessaExt (recommended) is used for this option.</v8:content>
 																				<v8:content>To take screenshots, use the VanessaExt add-in instead of the screenshot creation command.
 For the option to work, it is necessary to enable the use of the VanessaExt external component.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>För att ta skärmbilder, använd VanessaExt-tillägget istället för kommandot för att skapa skärmbilder.
+För att alternativet ska fungera är det nödvändigt att aktivera användningen av den externa komponenten VanessaExt.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -18326,6 +20144,10 @@ For the option to work, it is necessary to enable the use of the VanessaExt exte
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page screenshots second row right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder andra raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -18348,6 +20170,10 @@ For the option to work, it is necessary to enable the use of the VanessaExt exte
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Если опция включена, то при возникновении ошибки, когда браузер подключен через debug порт, будет выполнена попытка сделать скриншот браузера.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om detta alternativ är aktiverat görs vid ett fel, när webbläsaren är ansluten via felsökningsporten, ett försök att ta en skärmbild av webbläsaren.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -18365,6 +20191,10 @@ For the option to work, it is necessary to enable the use of the VanessaExt exte
 															<v8:lang>en</v8:lang>
 															<v8:content>Screenshots page third line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sida skärmbilder tredje raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<ShowTitle>false</ShowTitle>
@@ -18379,6 +20209,10 @@ For the option to work, it is necessary to enable the use of the VanessaExt exte
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page screenshots third row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder tredje raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -18491,6 +20325,10 @@ For the option to work, it is necessary to enable the use of the VanessaExt exte
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Screenshots directory.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Skärmbildskatalog.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -18508,6 +20346,10 @@ For the option to work, it is necessary to enable the use of the VanessaExt exte
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Screenshots page third row right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder tredje raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -18531,6 +20373,11 @@ You can use the * character to escape one or more characters in a process name.<
 																				<v8:content>Список имен процессов через точку с запятой.
 Можно использовать символ *, чтобы экранировать один или несколько символов в имени процесса.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>En semikolonavskild lista med processnamn.
+Du kan använda tecknet * för att ersätta ett eller flera tecken i ett processnamn.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -18548,6 +20395,10 @@ You can use the * character to escape one or more characters in a process name.<
 															<v8:lang>en</v8:lang>
 															<v8:content>Page screenshots fourth line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sida skärmbilder fjärde raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>NormalSeparation</Representation>
@@ -18563,6 +20414,10 @@ You can use the * character to escape one or more characters in a process name.<
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page screenshots fourth row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder fjärde raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -18581,6 +20436,10 @@ You can use the * character to escape one or more characters in a process name.<
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>How to take screenshots with an external component</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Hur man tar skärmbilder med en extern komponent</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Top</TitleLocation>
@@ -18601,6 +20460,10 @@ You can use the * character to escape one or more characters in a process name.<
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Full Screen</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Helskärm</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:decimal">0</Value>
 																			</xr:Value>
@@ -18618,6 +20481,10 @@ You can use the * character to escape one or more characters in a process name.<
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Current test client window</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktuellt testklientfönster</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:decimal">1</Value>
 																			</xr:Value>
@@ -18634,6 +20501,10 @@ You can use the * character to escape one or more characters in a process name.<
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>All test client windows</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Alla testklientfönster</v8:content>
 																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:decimal">2</Value>
@@ -18656,6 +20527,12 @@ You can use the * character to escape one or more characters in a process name.<
 &lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Current Test Client Window&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; - Gets a screenshot of only the active test client window.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;All testing client windows&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; - gets a screenshot of all testing client windows&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>&lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Helskärm&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; - Tar en skärmbild av hela skärmen, inklusive operativsystemets aktivitetsfält.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Aktuellt testklientfönster&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; - Tar en skärmbild av enbart det aktiva testklientfönstret.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Alla testklientfönster&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; - tar en skärmbild av alla testklientfönster&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -18670,6 +20547,10 @@ You can use the * character to escape one or more characters in a process name.<
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Screenshots page fourth row right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida skärmbilder fjärde raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -18786,6 +20667,13 @@ You can use the * character to escape one or more characters in a process name.<
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;1. &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;"C: \ Program Files (x86) \ IrfanView \ i_view32.exe" / capture = 1 / convert =&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;2. &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;nircmd savescreenshot&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Fältet anger konsolkommandot som kommer att användas vid skärmbildstagning.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Till exempel:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;1. &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;"C: \ Program Files (x86) \ IrfanView \ i_view32.exe" / capture = 1 / convert =&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;2. &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;b&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;nircmd savescreenshot&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -18894,6 +20782,10 @@ You can use the * character to escape one or more characters in a process name.<
 															<v8:lang>en</v8:lang>
 															<v8:content>General</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Allmänt</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -18911,6 +20803,10 @@ You can use the * character to escape one or more characters in a process name.<
 																	<v8:lang>en</v8:lang>
 																	<v8:content>General report settings group first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp allmänna rapportinställningar första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -18926,6 +20822,10 @@ You can use the * character to escape one or more characters in a process name.<
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>General report settings group first row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp allmänna rapportinställningar första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -18945,6 +20845,10 @@ You can use the * character to escape one or more characters in a process name.<
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Append assembly name to script name</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Lägg till byggnamn till skriptnamn</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Right</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -18960,6 +20864,10 @@ You can use the * character to escape one or more characters in a process name.<
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>This option is used when one report (e.g. Allure) is generated for several similar assemblies (e.g., the same tests). In this case "Current assembly name" field value will be added to the scenario name to avoid non-unique names. </v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Det här alternativet används när en rapport (t.ex. Allure) genereras för flera liknande byggen (t.ex. samma tester). I detta fall läggs värdet i fältet "Aktuellt byggnamn" till scenarionamnet för att undvika icke-unika namn. </v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -18978,6 +20886,10 @@ You can use the * character to escape one or more characters in a process name.<
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>General report settings group first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp allmänna rapportinställningar första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -19005,6 +20917,12 @@ You can use the * character to escape one or more characters in a process name.<
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Details here:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;link https://pr-mex.github.io/vanessa-automation/dev/ReturnStatus/ReturnStatus&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;https://pr-mex.github.io/vanessa-automation/dev/ReturnStatus/ReturnStatus&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om flaggan är satt kommer Vanessa Automation att ladda upp skriptkörningsstatusen till en fil.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Detaljer här:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;link https://pr-mex.github.io/vanessa-automation/dev/ReturnStatus/ReturnStatus&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;https://pr-mex.github.io/vanessa-automation/dev/ReturnStatus/ReturnStatus&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -19025,6 +20943,10 @@ You can use the * character to escape one or more characters in a process name.<
 																	<v8:lang>en</v8:lang>
 																	<v8:content>General report settings group second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp allmänna rapportinställningar andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -19040,6 +20962,10 @@ You can use the * character to escape one or more characters in a process name.<
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>General report settings group second row left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp allmänna rapportinställningar andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -19059,6 +20985,10 @@ You can use the * character to escape one or more characters in a process name.<
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Current build name</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Aktuellt byggnamn</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -19074,6 +21004,10 @@ You can use the * character to escape one or more characters in a process name.<
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Unique assembly name used along with the parameter "Add uploading conditions to scenario name".</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Unikt byggnamn som används tillsammans med parametern "Lägg till uppladdningsvillkor till scenarionamn".</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -19088,6 +21022,10 @@ You can use the * character to escape one or more characters in a process name.<
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>General report settings group second row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp allmänna rapportinställningar andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -19110,6 +21048,10 @@ You can use the * character to escape one or more characters in a process name.<
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Путь к файлу, в который будет выгружен статус выполнения сценариев.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Sökvägen till filen där skriptkörningsstatusen laddas upp.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -19129,6 +21071,10 @@ You can use the * character to escape one or more characters in a process name.<
 															<v8:lang>en</v8:lang>
 															<v8:content>Test video record</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Testa videoinspelning</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -19145,6 +21091,10 @@ You can use the * character to escape one or more characters in a process name.<
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group video recording of passing tests left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp videoinspelning av godkända tester vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -19173,6 +21123,11 @@ You can use the * character to escape one or more characters in a process name.<
 																				<v8:content>Enables video recording during the test. You must enable the use of an external VanessaExt add-in.
 A video file will be created for each scenario.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar videoinspelning under testet. Du måste aktivera användningen av det externa VanessaExt-tillägget.
+En videofil skapas för varje scenario.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -19195,6 +21150,10 @@ A video file will be created for each scenario.</v8:content>
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Количество кадров для записи видео.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Antal bildrutor för videoinspelning.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -19213,6 +21172,10 @@ A video file will be created for each scenario.</v8:content>
 																			<v8:item>
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Команда для запуска приложения "ffmpeg". Рекомендуется прописать путь к ffmpeg в системной переменной "path".</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Kommandot för att köra programmet "ffmpeg". Det rekommenderas att ställa in sökvägen till ffmpeg i systemvariabeln "path".</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -19234,6 +21197,10 @@ A video file will be created for each scenario.</v8:content>
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Каталог для видео файлов.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Katalog för videofiler.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -19254,6 +21221,10 @@ A video file will be created for each scenario.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Logging events to a file or console</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Logga händelser till fil eller konsol</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -19263,6 +21234,10 @@ A video file will be created for each scenario.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Logging script execution events to a file or console</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Logga skriptkörningshändelser till fil eller konsol</v8:content>
 														</v8:item>
 													</ToolTip>
 													<Group>Vertical</Group>
@@ -19281,6 +21256,10 @@ A video file will be created for each scenario.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>group log text first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>grupp loggtext första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -19296,6 +21275,10 @@ A video file will be created for each scenario.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>group log text first line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>grupp loggtext första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -19329,6 +21312,14 @@ Log events:
 2. Error event
 Log output is possible either to a file, or to the console, or to a file and a console at the same time.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar scenariokörningslogg.
+Logghändelser:
+1. Scenariokörning påbörjad
+2. Felhändelse
+Loggutmatning är möjlig antingen till en fil, eller till konsolen, eller till en fil och konsol samtidigt.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -19346,6 +21337,10 @@ Log output is possible either to a file, or to the console, or to a file and a c
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>group log text first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>grupp loggtext första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -19371,6 +21366,11 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																						<v8:content>Включает вывод лога в консоль.
 Для работы опции необходимо включить использование компоненты VanessaExt.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar loggning till konsolen.
+För att detta alternativ ska fungera måste du aktivera användningen av VanessaExt-tillägget.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -19391,6 +21391,10 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																	<v8:lang>en</v8:lang>
 																	<v8:content>group log text second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>grupp loggtext andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -19406,6 +21410,10 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>group log text second line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>grupp loggtext andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -19431,6 +21439,10 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Writes step beginning event to the log.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Skriver stegstarthändelsen till loggen.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -19445,6 +21457,10 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>group log text second line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>grupp loggtext andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -19474,6 +21490,13 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 2. Сколько упало/успешно/пропущено
 3. Прошло/осталось времени</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Mer detaljer i loggen
+1. Totalt antal tester
+2. Hur många misslyckades / lyckades / hoppades över
+3. Tid passerad / kvar</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -19491,6 +21514,10 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																	<v8:lang>en</v8:lang>
 																	<v8:content>group log text third line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>grupp loggtext tredje raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -19506,6 +21533,10 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>group log text third line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>grupp loggtext tredje raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -19532,6 +21563,11 @@ For this option to work, you must enable the use of the VanessaExt addin.</v8:co
 																						<v8:content>Vanessa Automation log file name.
 If the field is empty, then the log will not be output to a text file.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Vanessa Automations loggfilsnamn.
+Om fältet är tomt skrivs loggen inte ut till en textfil.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -19549,6 +21585,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group log text third row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp loggtext tredje raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -19571,6 +21611,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>The user's password is masked in the log /P"*****"</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Användarens lösenord maskeras i loggen /P"*****"</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -19602,6 +21646,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 															<v8:lang>ro</v8:lang>
 															<v8:content>Allure</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Allure</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -19619,6 +21667,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group allure settings</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp Allure-inställningar</v8:content>
+																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
 															<Representation>None</Representation>
@@ -19634,6 +21686,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Main settings</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Huvudinställningar</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -19652,6 +21708,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Allure group basic settings first line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allure-grupp grundinställningar första raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -19667,6 +21727,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings first row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar första raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -19686,6 +21750,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Form a report in Allure format</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Skapa en rapport i Allure-format</v8:content>
+																								</v8:item>
 																							</Title>
 																							<TitleLocation>Right</TitleLocation>
 																							<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -19701,6 +21769,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Create a scenario execution report in Allure format.</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Skapa en scenariokörningsrapport i Allure-format.</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -19719,6 +21791,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group basic settings first row right column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp grundinställningar första raden höger kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Group>Vertical</Group>
@@ -19742,6 +21818,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:item>
 																										<v8:lang>ru</v8:lang>
 																										<v8:content>Если опция включена, то в параметрах шагов, в которых использовались переменные, имена переменных будут заменены на их значения.</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Om detta alternativ är aktiverat ersätts variabelnamnen i parametrarna för de steg där variabler användes med deras värden.</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -19848,6 +21928,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Enter tags in the field. If the tag is detected in the feature, the whole feature will not be uploaded. If the tag is found in the scenario, only this scenario will not be uploaded.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Ange taggar i fältet. Om taggen hittas i funktionen laddas inte hela funktionen upp. Om taggen hittas i scenariot laddas bara detta scenario inte upp.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</InputField>
@@ -19865,6 +21949,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Group allure basic settings second line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Grupp Allure grundinställningar andra raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -19880,6 +21968,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings second row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar andra raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -19986,6 +22078,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Temporary directory for Allure results</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Tillfällig katalog för Allure-resultat</v8:content>
+																								</v8:item>
 																							</ToolTip>
 																							<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																							<ChoiceButton>true</ChoiceButton>
@@ -20001,6 +22097,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Allure reports directory. When run locally, the directory will be cleaned up each time the scripts are run.</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Allure-rapportkatalog. Vid lokal körning rensas katalogen varje gång skripten körs.</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -20020,6 +22120,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings second row right column</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar andra raden höger kolumn</v8:content>
+																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
 																					<ShowTitle>false</ShowTitle>
@@ -20035,6 +22139,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Allure report directory (several builds)</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Allure-rapportkatalog (flera byggen)</v8:content>
 																								</v8:item>
 																							</Title>
 																							<TitleLocation>Top</TitleLocation>
@@ -20052,6 +22160,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>The directory in which report data is generated in Allure format, and subdirectories will be created for each assembly. This parameter takes precedence and the value of the "Allure Report Catalog" parameter will be ignored.</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Katalogen där rapportdata genereras i Allure-format, och underkataloger skapas för varje bygge. Denna parameter har företräde och värdet för parametern "Allure-rapportkatalog" ignoreras.</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -20073,6 +22185,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Allure group basic settings third line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allure-grupp grundinställningar tredje raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20088,6 +22204,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings third row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar tredje raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20112,6 +22232,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Sets first level of grouping in Allure report on the Behaviors tab. See Help info for details.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Anger första nivån av gruppering i Allure-rapporten på fliken Beteenden. Se hjälpinformationen för detaljer.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</InputField>
@@ -20126,6 +22250,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings third row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar tredje raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20148,6 +22276,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Sets second level of grouping in Allure report on the Behaviors tab. See Help info for details.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Anger andra nivån av gruppering i Allure-rapporten på fliken Beteenden. Se hjälpinformationen för detaljer.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</InputField>
@@ -20165,6 +22297,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Allure group basic settings fourth line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allure-grupp grundinställningar fjärde raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20180,6 +22316,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group basic settings fourth row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp grundinställningar fjärde raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20204,6 +22344,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Sets third level of grouping in Allure report on the Behaviors tab. See Help info for details.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Anger tredje nivån av gruppering i Allure-rapporten på fliken Beteenden. Se hjälpinformationen för detaljer.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</InputField>
@@ -20218,6 +22362,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings fourth row right column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar fjärde raden höger kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20235,6 +22383,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Hierarchy directory</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Hierarkikatalog</v8:content>
+																								</v8:item>
 																							</Title>
 																							<TitleLocation>Top</TitleLocation>
 																							<ToolTip>
@@ -20245,6 +22397,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Directory relative to which you need to build hierarchy</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Katalog i förhållande till vilken hierarkin ska byggas</v8:content>
 																								</v8:item>
 																							</ToolTip>
 																							<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -20261,6 +22417,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>The directory for features hierarchy calculation. See Help info for details.</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Katalogen för beräkning av feature-hierarki. Se hjälpinformationen för detaljer.</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -20282,6 +22442,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Allure group basic settings fifth line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allure-grupp grundinställningar femte raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20297,6 +22461,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings fifth row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar femte raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20324,6 +22492,11 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;List of tags separated by ";".&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;If the script contains such a tag, then the script will not be executed and the Allure report will have the skipped status.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Lista över taggar separerade med ";".&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om skriptet innehåller en sådan tagg kommer skriptet inte att köras och Allure-rapporten kommer att ha statusen överhoppad.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20338,6 +22511,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings fifth row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar femte raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20360,6 +22537,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Sets grouping value for Allure report on the Suites tab. See Help info for details.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Anger grupperingsvärde för Allure-rapporten på fliken Sviter. Se hjälpinformationen för detaljer.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</InputField>
@@ -20377,6 +22558,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Allure group basic settings sixth line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allure-grupp grundinställningar sjätte raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20392,6 +22577,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings sixth row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar sjätte raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20409,6 +22598,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure group main settings sixth row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-grupp huvudinställningar sjätte raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20429,6 +22622,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Appendices to the report</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Bilagor till rapporten</v8:content>
+																		</v8:item>
 																	</Title>
 																	<ToolTip>
 																		<v8:item>
@@ -20438,6 +22635,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Allure report applications</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Allure-rapportbilagor</v8:content>
 																		</v8:item>
 																	</ToolTip>
 																	<Group>Vertical</Group>
@@ -20456,6 +22657,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Attachment group to allure report first line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Bilagegrupp till Allure-rapport första raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20471,6 +22676,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report attachment group first row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportbilagegrupp första raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20496,6 +22705,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>If an error occurs, a log will be attached to the script. Data is taken from the moment the scenario starts.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Vid ett fel bifogas en logg till skriptet. Data tas från det ögonblick scenariot startar.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20510,6 +22723,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report attachment group first row right column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportbilagegrupp första raden höger kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20533,6 +22750,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>If the option is enabled, then when an error occurs, data will be collected on the network connections of the PC on which the tests were run.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Om alternativet är aktiverat samlas vid ett fel data om nätverksanslutningarna på den dator där testerna kördes in.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20550,6 +22771,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Attachment group to allure report second line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Bilagegrupp till Allure-rapport andra raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20565,6 +22790,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report application group second row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportapplikationsgrupp andra raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20590,6 +22819,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>If the option is enabled, states of items of the active form will be collected in xlsx format in case of an error.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Om alternativet är aktiverat samlas tillstånden för objekt i det aktiva formuläret in i xlsx-format vid fel.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20604,6 +22837,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Attachment group to allure report second row right column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Bilagegrupp till Allure-rapport andra raden höger kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20627,6 +22864,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>If the option is enabled, states of items of all forms opened in TestClient will be collected in xlsx format.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Om alternativet är aktiverat samlas tillstånden för objekt i alla formulär som är öppna i TestClient in i xlsx-format.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20644,6 +22885,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Attachment group to allure report third line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Bilagegrupp till Allure-rapport tredje raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20659,6 +22904,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report attachment group third row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportbilagegrupp tredje raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20684,6 +22933,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>If the option is enabled, then when an error occurs, data on running OS processes will be collected.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Om alternativet är aktiverat samlas vid ett fel data om körande OS-processer in.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20698,6 +22951,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report attachment group third row right column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportbilagegrupp tredje raden höger kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20721,6 +22978,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>en</v8:lang>
 																										<v8:content>If the option is enabled, data with Context and Global Context variable values will be collected when an error occurs.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Om alternativet är aktiverat samlas data med kontextvariabel- och globaltkontextvariabelvärden in vid ett fel.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20738,6 +22999,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Allure report attachment group fourth line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allure-rapportbilagegrupp fjärde raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20753,6 +23018,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report attachment group fourth row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportbilagegrupp fjärde raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20778,6 +23047,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>ru</v8:lang>
 																										<v8:content>Файлы отчетов и их эталонов будут прикладываться к отчету Allure в формате mxl.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Filer med rapporter och deras mallar bifogas till Allure-rapporten i mxl-format.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20792,6 +23065,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report attachment group fourth row right column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportbilagegrupp fjärde raden höger kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20815,6 +23092,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>ru</v8:lang>
 																										<v8:content>Все mxl файлы, которые будут приложены к отчету Allure будут сохраняться в формате HTML. Это упрощает открытие и просмотр результата.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Alla mxl-filer som bifogas till Allure-rapporten sparas i HTML-format. Detta gör det enklare att öppna och visa resultatet.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20832,6 +23113,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Application group to allure report fifth line</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Applikationsgrupp till Allure-rapport femte raden</v8:content>
+																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
 																			<Representation>None</Representation>
@@ -20847,6 +23132,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report attachment group fifth row left column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportbilagegrupp femte raden vänster kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Width>50</Width>
@@ -20871,6 +23160,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																										<v8:lang>ru</v8:lang>
 																										<v8:content>Файлы отчетов и их эталонов будут прикладываться к отчету Allure в формате xlsx.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Filer med rapporter och deras mallar bifogas till Allure-rapporten i xlsx-format.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20885,6 +23178,10 @@ If the field is empty, then the log will not be output to a text file.</v8:conte
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Allure report application group fifth row right column</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allure-rapportapplikationsgrupp femte raden höger kolumn</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Representation>None</Representation>
@@ -20926,6 +23223,19 @@ An example result can be seen &lt;link https://www.youtube.com/watch?v=1xnp6CxCk
 magick convert file.pdf file.png
 Пример результата можно посмотреть &lt;link https://www.youtube.com/watch?v=1xnp6CxCktA&amp;list=PLalsS95_a3a8iVPCLjFMY2wj4ZMG2XpVH&amp;index=3&amp;ab_channel=VSL&gt;тут&lt;/&gt;.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Om detta alternativ är aktiverat kommer ytterligare filer att genereras vid jämförelse av en layout med en referens eller vid jämförelse av en tabell med en referens:
+- en bild som innehåller skillnaden mellan referensen och det aktuella värdet för tabellen eller layouten
+- en bild av det aktuella värdet
+- en bild av referensvärdet
+- en gif-fil som visar skillnaden mellan det aktuella och referensvärdet.
+En ytterligare sektion kommer också att visas i Allure-rapporten, där du bekvämt kan visa en jämförelse av referensen och det aktuella värdet.
+För att detta alternativ ska fungera är det nödvändigt att ImageMagick version 7 eller högre och ghostscript-paketet &lt;link https://www.ghostscript.com/download.html&gt;https://www.ghostscript.com/download.html&lt;/&gt;, som konverterar pdf-filer till bilder, är installerat på datorn där Vanessa Automation körs.
+Det är också nödvändigt att kommandon av följande form kan köras på datorn:
+magick convert file.pdf file.png
+Ett exempelresultat kan ses &lt;link https://www.youtube.com/watch?v=1xnp6CxCktA&amp;list=PLalsS95_a3a8iVPCLjFMY2wj4ZMG2XpVH&amp;index=3&amp;ab_channel=VSL&gt;här&lt;/&gt;.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</CheckBoxField>
@@ -20944,6 +23254,10 @@ magick convert file.pdf file.png
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Allure labels data</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Allure-etikettdata</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Vertical</Group>
@@ -20970,6 +23284,10 @@ magick convert file.pdf file.png
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Allure labels data</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allure-etikettdata</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleTextColor>#009646</TitleTextColor>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -20993,6 +23311,14 @@ magick convert file.pdf file.png
 If a regular expression is specified in a table row, then a regular expression from this table is applied to each script tag, and if the tag matches it, then a tag in the TagName: Value format will be added to the report.
 If no regular expression is specified in a table row, then the label is added unconditionally.
 You can read more about why this may be needed here
+&lt;link https://habr.com/ru/company/sberbank/blog/359302/&gt;https://habr.com/ru/company/sberbank/blog/359302/&lt;/&gt;</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Tabellen används för att mappa skripttaggar till etiketter.
+Om ett reguljärt uttryck anges i en tabellrad, tillämpas det reguljära uttrycket från denna tabell på varje skripttagg, och om taggen matchar det läggs en tagg i formatet TagName: Value till i rapporten.
+Om inget reguljärt uttryck anges i en tabellrad läggs etiketten till ovillkorligt.
+Du kan läsa mer om varför detta kan behövas här
 &lt;link https://habr.com/ru/company/sberbank/blog/359302/&gt;https://habr.com/ru/company/sberbank/blog/359302/&lt;/&gt;</v8:content>
 																					</v8:item>
 																				</Title>
@@ -21067,6 +23393,10 @@ You can read more about why this may be needed here
 														</v8:item>
 														<v8:item>
 															<v8:lang>ro</v8:lang>
+															<v8:content>JUnit</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
 															<v8:content>JUnit</v8:content>
 														</v8:item>
 													</Title>
@@ -21179,6 +23509,10 @@ You can read more about why this may be needed here
 																		<v8:lang>ru</v8:lang>
 																		<v8:content>Формировать отчет в формате JUnit по результатам выполнения сценариев.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Generera en rapport i JUnit-format baserat på resultaten av skriptkörning.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<Events>
@@ -21194,6 +23528,10 @@ You can read more about why this may be needed here
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>jUnit settings</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>jUnit-inställningar</v8:content>
 																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
@@ -21300,6 +23638,10 @@ You can read more about why this may be needed here
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Temporary directory for JUnit files</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Tillfällig katalog för JUnit-filer</v8:content>
+																		</v8:item>
 																	</ToolTip>
 																	<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																	<ChoiceButton>true</ChoiceButton>
@@ -21315,6 +23657,10 @@ You can read more about why this may be needed here
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Report generation directory.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Katalog för rapportgenerering.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -21332,6 +23678,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Add screenshots to report (for GitLab)</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Lägg till skärmbilder i rapporten (för GitLab)</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
@@ -21352,6 +23702,12 @@ You can read more about why this may be needed here
 																				<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;From version &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://docs.gitlab.com/ee/ci/unit_test_reports.html#viewing-junit-screenshots-on-gitlab&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;13.12&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; screenshots can be added to jUnit.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;For everything to work correctly - the Screenshot Directory must be located inside the Project Directory.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Save the screenshots folder as artifacts.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Från version &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://docs.gitlab.com/ee/ci/unit_test_reports.html#viewing-junit-screenshots-on-gitlab&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;13.12&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; kan skärmbilder läggas till i jUnit.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;För att allt ska fungera korrekt måste skärmbildskatalogen finnas inuti projektkatalogen.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Spara skärmbildsmappen som artefakter.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -21374,6 +23730,10 @@ You can read more about why this may be needed here
 															<v8:lang>ro</v8:lang>
 															<v8:content>СППР</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>ASDS</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -21383,6 +23743,10 @@ You can read more about why this may be needed here
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Applied Solution Design System</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Tillämpad lösningsdesignsystem</v8:content>
 														</v8:item>
 													</ToolTip>
 													<Group>Vertical</Group>
@@ -21408,6 +23772,10 @@ You can read more about why this may be needed here
 																		<v8:lang>ru</v8:lang>
 																		<v8:content>Формировать отчет в формате СППР по результатам выполнения сценариев.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Generera en rapport i SPPR-format baserat på scenarioresultaten.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<Events>
@@ -21424,6 +23792,10 @@ You can read more about why this may be needed here
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group SPPR Settings</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp SPPR-inställningar</v8:content>
+																</v8:item>
 															</Title>
 															<ToolTip>
 																<v8:item>
@@ -21433,6 +23805,10 @@ You can read more about why this may be needed here
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group SPPR Settings</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp SPPR-inställningar</v8:content>
 																</v8:item>
 															</ToolTip>
 															<Group>Vertical</Group>
@@ -21450,6 +23826,10 @@ You can read more about why this may be needed here
 																			<v8:lang>en</v8:lang>
 																			<v8:content>SPPR settings group first line</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>SPPR-inställningsgrupp första raden</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<Representation>None</Representation>
@@ -21465,6 +23845,10 @@ You can read more about why this may be needed here
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>SPPR settings group first line left column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>SPPR-inställningsgrupp första raden vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -21491,6 +23875,10 @@ You can read more about why this may be needed here
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Report directory.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Rapportkatalog.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																					<Events>
@@ -21508,6 +23896,10 @@ You can read more about why this may be needed here
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>SPPR settings group first line right column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>SPPR-inställningsgrupp första raden höger kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Representation>None</Representation>
@@ -21529,6 +23921,10 @@ You can read more about why this may be needed here
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Configuration name for the report</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Konfigurationsnamn för rapporten</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -21546,6 +23942,10 @@ You can read more about why this may be needed here
 																			<v8:lang>en</v8:lang>
 																			<v8:content>SPPR settings group second line</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>SPPR-inställningsgrupp andra raden</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<Representation>None</Representation>
@@ -21561,6 +23961,10 @@ You can read more about why this may be needed here
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>SPPR settings group second line left column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>SPPR-inställningsgrupp andra raden vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -21583,6 +23987,10 @@ You can read more about why this may be needed here
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Configuration version for report</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Konfigurationsversion för rapporten</v8:content>
 																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
@@ -21607,6 +24015,10 @@ You can read more about why this may be needed here
 														</v8:item>
 														<v8:item>
 															<v8:lang>ro</v8:lang>
+															<v8:content>Cucumber</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
 															<v8:content>Cucumber</v8:content>
 														</v8:item>
 													</Title>
@@ -21719,6 +24131,10 @@ You can read more about why this may be needed here
 																		<v8:lang>ru</v8:lang>
 																		<v8:content>Формировать отчет в формате Cucumber по результатам выполнения сценариев.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Generera en rapport i Cucumber-format baserat på skriptkörningsresultaten.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<Events>
@@ -21734,6 +24150,10 @@ You can read more about why this may be needed here
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Cucumber settings</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Cucumber-inställningar</v8:content>
 																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
@@ -21840,6 +24260,10 @@ You can read more about why this may be needed here
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Temporary directory for Cucumber files</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Tillfällig katalog för Cucumber-filer</v8:content>
+																		</v8:item>
 																	</ToolTip>
 																	<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																	<ChoiceButton>true</ChoiceButton>
@@ -21855,6 +24279,10 @@ You can read more about why this may be needed here
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Report directory.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Rapportkatalog.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -21876,6 +24304,10 @@ You can read more about why this may be needed here
 															<v8:lang>en</v8:lang>
 															<v8:content>Json</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Json</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -21893,6 +24325,10 @@ You can read more about why this may be needed here
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group error log text first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp fellogg text första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -21908,6 +24344,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Error log group text first line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Fellogggrupp text första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -21933,6 +24373,10 @@ You can read more about why this may be needed here
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Create json file with the detailed information for each error.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Skapa json-fil med detaljerad information för varje fel.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -21950,6 +24394,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Error log group text first line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Fellogggrupp text första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -21973,6 +24421,10 @@ You can read more about why this may be needed here
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Включает сбор данных о значениях переменных.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar insamling av data om variabelvärden.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -21990,6 +24442,10 @@ You can read more about why this may be needed here
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group error log text second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp fellogg text andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22005,6 +24461,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Error log group text second line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Fellogggrupp text andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22030,6 +24490,10 @@ You can read more about why this may be needed here
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If the option is on, the status of the elements of the active form will be collected in mxl format.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om alternativet är aktiverat samlas statusen för elementen i det aktiva formuläret in i mxl-format.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -22044,6 +24508,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Error log group text second line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Fellogggrupp text andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -22067,6 +24535,10 @@ You can read more about why this may be needed here
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If the option is on, the status of the elements of all forms opened in TestClient will be collected in mxl format.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om alternativet är aktiverat samlas statusen för elementen i alla formulär som är öppna i TestClient in i mxl-format.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -22084,6 +24556,10 @@ You can read more about why this may be needed here
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group error log text third line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp fellogg text tredje raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22099,6 +24575,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Error log group text third line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Fellogggrupp text tredje raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22124,6 +24604,10 @@ You can read more about why this may be needed here
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If the option is enabled, then when an error occurs, data on running OS processes will be collected.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om alternativet är aktiverat samlas vid ett fel data om körande OS-processer in.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -22138,6 +24622,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group error log text third line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp fellogg text tredje raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -22161,6 +24649,10 @@ You can read more about why this may be needed here
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If the option is enabled, then when an error occurs, data will be collected on the network connections of the PC on which the tests were run.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om alternativet är aktiverat samlas vid ett fel data om nätverksanslutningarna på den dator där testerna kördes in.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -22178,6 +24670,10 @@ You can read more about why this may be needed here
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group error log text fourth line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp fellogg text fjärde raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22193,6 +24689,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group error log text fourth line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp fellogg text fjärde raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22219,6 +24719,10 @@ You can read more about why this may be needed here
 																						<v8:lang>en</v8:lang>
 																						<v8:content>A directory for generating files with data about errors and the state of form elements and other data related to the error. The directory is cleared when the scripts start running.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>En katalog för att generera filer med data om fel och tillståndet för formulärelement samt annan data relaterad till felet. Katalogen rensas när skripten börjar köras.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -22240,6 +24744,10 @@ You can read more about why this may be needed here
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Internal format</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Internt format</v8:content>
 														</v8:item>
 													</Title>
 													<Group>Horizontal</Group>
@@ -22351,6 +24859,10 @@ You can read more about why this may be needed here
 																		<v8:lang>en</v8:lang>
 																		<v8:content>Enables a scenario execution report in the internal format.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Aktiverar en scenariokörningsrapport i internt format.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 														</CheckBoxField>
@@ -22457,6 +24969,10 @@ You can read more about why this may be needed here
 															<v8:lang>en</v8:lang>
 															<v8:content>UI Automation</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>UI Automation</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -22474,6 +24990,10 @@ You can read more about why this may be needed here
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Vanessa ext chrome autoinstruction group first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>VanessaExt Chrome autoinstruktionsgrupp första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22489,6 +25009,10 @@ You can read more about why this may be needed here
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Autoinstruction group vanessa ext chrome first line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Autoinstruktionsgrupp VanessaExt Chrome första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22523,6 +25047,14 @@ If the option is enabled, the mouse cursor is first moved to this button, and th
 Если опция включена, то курсор мышки сначала будет перемещён к данной кнопке, а затем уже кнопка будет нажата.
 </v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Aktiverar användningen av UI Automation-mekanismen i Windows för att emulera rörelse och musklick i steg från Vanessa Automations standardstegbibliotek.
+Till exempel, när alternativet är inaktiverat, klickar steget
+And I click on the "TitleButton"
+bare på knappen utan att utföra några interaktiva åtgärder.
+Om alternativet är aktiverat flyttas muspekaren först till denna knapp och sedan trycks knappen ned.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -22537,6 +25069,10 @@ If the option is enabled, the mouse cursor is first moved to this button, and th
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Autoinstruction group vanessa ext chrome first row right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Autoinstruktionsgrupp VanessaExt Chrome första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -22557,6 +25093,10 @@ If the option is enabled, the mouse cursor is first moved to this button, and th
 															<v8:lang>en</v8:lang>
 															<v8:content>Working with the browser</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Arbeta med webbläsaren</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -22574,6 +25114,10 @@ If the option is enabled, the mouse cursor is first moved to this button, and th
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group for setting up auto-instructions when working with a browser first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22589,6 +25133,10 @@ If the option is enabled, the mouse cursor is first moved to this button, and th
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser first line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22616,6 +25164,11 @@ If the option is enabled, the mouse cursor is first moved to this button, and th
 																						<v8:content>Allows to execute external commands in the browser using WebSocket.
 For the option to work, you must enable the use of the VanessaExt component.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Tillåter att köra externa kommandon i webbläsaren via WebSocket.
+För att alternativet ska fungera måste du aktivera användningen av VanessaExt-komponenten.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -22630,6 +25183,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser first line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare första raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -22648,6 +25205,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group for setting up auto-instructions when working with a browser third line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare tredje raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22663,6 +25224,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser third line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare tredje raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22688,6 +25253,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Allows to continue running the scenario if the form item is not found in the browser.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Tillåter att fortsätta köra scenariot om formulärelementet inte hittas i webbläsaren.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</CheckBoxField>
@@ -22702,6 +25271,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser third line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare tredje raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -22720,6 +25293,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group for setting up auto-instructions when working with a browser fourth line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare fjärde raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22735,6 +25312,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser fourth line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare fjärde raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22754,6 +25335,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Screen scaling factor</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Skärmskalningsfaktor</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -22769,6 +25354,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																						<v8:lang>en</v8:lang>
 																						<v8:content>The default value is one. If screen scaling is used in the OS, then you need to change to set the appropriate value. For example, when scaling to 150% in the OS, you need to set the coefficient value to 1.5.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Standardvärdet är ett. Om skärmskalning används i operativsystemet behöver du ändra till att ställa in lämpligt värde. Till exempel, vid skalning till 150% i operativsystemet behöver du ställa in koefficientvärdet till 1,5.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -22783,6 +25372,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser fourth line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare fjärde raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -22801,6 +25394,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group for setting up auto-instructions when working with a browser second line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare andra raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -22816,6 +25413,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser second line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare andra raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -22833,6 +25434,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group for setting up auto-instructions when working with a browser second line right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp för inställning av autoinstruktioner vid arbete med webbläsare andra raden höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -22853,6 +25458,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 															<v8:lang>en</v8:lang>
 															<v8:content>Image search</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Bildsökning</v8:content>
+														</v8:item>
 													</Title>
 													<Behavior>Collapsible</Behavior>
 													<Collapsed>true</Collapsed>
@@ -22868,6 +25477,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Image search group left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Bildsökningsgrupp vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -22894,6 +25507,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Если опция включена, то шаги, выполняющие поиск картинок на экране, будут использовать внешнюю компоненту VanessaExt вместо использования SikuliX.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om detta alternativ är aktiverat använder stegen som utför bildsökning på skärmen det externa tillägget VanessaExt istället för SikuliX.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -22916,6 +25533,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Число, определяющее порог поиска картинки на экране. Значение может быть задано в диапазоне от 0 до 1.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Ett tal som bestämmer tröskeln för sökning av en bild på skärmen. Värdet kan ställas in i intervallet 0 till 1.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</InputField>
@@ -22933,6 +25554,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 															<v8:lang>en</v8:lang>
 															<v8:content>Keyboard emulation</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Tangentbordsemulering</v8:content>
+														</v8:item>
 													</Title>
 													<Behavior>Collapsible</Behavior>
 													<Collapsed>true</Collapsed>
@@ -22948,6 +25573,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Keyboard emulation group left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Tangentbordsemuleringsgrupp vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -22973,6 +25602,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Enables emulation of keyboard input using VanessaExt add-in</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar emulering av tangentbordsinmatning med VanessaExt-tillägget</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -22990,6 +25623,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 															<v8:lang>en</v8:lang>
 															<v8:content>Mouse emulation</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Musemulering</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -23006,6 +25643,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Mouse action emulation settings group first line</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp inställningar för musåtgärdsemulering första raden</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -23032,6 +25673,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Enables mouse movement emulation using VanessaExt add-in.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar musrörelseemulering med VanessaExt-tillägget.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -23050,6 +25695,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Mouse coordinate offset</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Muskoordinatförskjutning</v8:content>
+																</v8:item>
 															</Title>
 															<Behavior>Collapsible</Behavior>
 															<Collapsed>true</Collapsed>
@@ -23065,6 +25714,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Mouse coordinates offset setting group left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp inställning muskoordinatförskjutning vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -23084,6 +25737,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Horizontal offset</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Horisontell förskjutning</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23099,6 +25756,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																						<v8:lang>en</v8:lang>
 																						<v8:content>It is used when it is necessary to shift the position of the mouse horizontally by a specified number of pixels. It can take both positive and negative values.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Används när det är nödvändigt att förskjuta musens position horisontellt med ett angivet antal pixlar. Kan ta både positiva och negativa värden.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -23113,6 +25774,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Mouse coordinates offset setting group right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp inställning muskoordinatförskjutning höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -23130,6 +25795,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Vertical offset</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Vertikal förskjutning</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23144,6 +25813,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>It is used when it is necessary to shift the position of the mouse vertically by a specified number of pixels. It can take both positive and negative values.</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Används när det är nödvändigt att förskjuta musens position vertikalt med ett angivet antal pixlar. Kan ta både positiva och negativa värden.</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -23162,6 +25835,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Mouse movement speed</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Musrörelsehastighet</v8:content>
+																</v8:item>
 															</Title>
 															<Behavior>Collapsible</Behavior>
 															<Collapsed>true</Collapsed>
@@ -23177,6 +25854,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Mouse movement speed group left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Musrörelsehastighetgrupp vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -23196,6 +25877,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Number of steps</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Antal steg</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23211,6 +25896,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Sets the number of micromovements (steps) that the mouse makes on its way. The default value is 150.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger antalet mikrorörelser (steg) som musen gör på sin väg. Standardvärdet är 150.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																		</InputField>
@@ -23225,6 +25914,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Mouse movement speed group right column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Musrörelsehastighetgrupp höger kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
@@ -23242,6 +25935,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Timeout between steps</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Timeout mellan steg</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23256,6 +25953,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Sets a pause in milliseconds between micro mouse movements. The default value is 3.</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Anger en paus i millisekunder mellan mikromusrörelser. Standardvärdet är 3.</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -23274,6 +25975,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Mouse click highlight</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Musklickmarkering</v8:content>
+																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
 															<Behavior>Collapsible</Behavior>
@@ -23290,6 +25995,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Highlight mouse clicks group first line</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp markera musklick första raden</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -23310,6 +26019,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Highlight mouse click</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Markera musklick</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Right</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23325,6 +26038,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>If this option is enabled, click highlighting will be enabled using the external VanessaExt component.</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Om detta alternativ är aktiverat aktiveras klickmarkering med den externa VanessaExt-komponenten.</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -23344,6 +26061,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Selecting a color for highlighting mouse clicks</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Val av färg för markering av musklick</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<ShowTitle>false</ShowTitle>
@@ -23358,6 +26079,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Group selection of color for highlighting mouse clicks left column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Grupp val av färg för markering av musklick vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -23382,6 +26107,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Colour</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Färg</v8:content>
+																						</v8:item>
 																					</Title>
 																					<TitleLocation>Top</TitleLocation>
 																					<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23397,6 +26126,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Number. Sets the color for highlighting mouse clicks.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Nummer. Anger färgen för markering av musklick.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -23411,6 +26144,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Group selection of color for highlighting mouse clicks left column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Grupp val av färg för markering av musklick vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Group>AlwaysHorizontal</Group>
@@ -23429,6 +26166,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Color selection</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Färgval</v8:content>
+																						</v8:item>
 																					</Title>
 																					<TitleLocation>Top</TitleLocation>
 																					<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23445,6 +26186,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Allows you to select a color using the standard color selection dialog.</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Låter dig välja en färg med hjälp av standardfärgvalsdialogrutan.</v8:content>
 																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
@@ -23466,6 +26211,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Other settings</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Övriga inställningar</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<Representation>None</Representation>
@@ -23481,6 +26230,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Highlighting mouse clicks</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Markering av musklick</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -23501,6 +26254,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Radius</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Radie</v8:content>
+																						</v8:item>
 																					</Title>
 																					<TitleLocation>Top</TitleLocation>
 																					<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23516,6 +26273,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Sets the radius of the click animation.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Anger radien för klickanimationen.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -23529,6 +26290,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Width</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Bredd</v8:content>
 																						</v8:item>
 																					</Title>
 																					<TitleLocation>Top</TitleLocation>
@@ -23545,6 +26310,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Sets the width of the click animation.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Anger bredden för klickanimationen.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -23559,6 +26328,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Highlighting mouse clicks</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Markering av musklick</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Group>Vertical</Group>
@@ -23576,6 +26349,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Duration</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Varaktighet</v8:content>
+																						</v8:item>
 																					</Title>
 																					<TitleLocation>Top</TitleLocation>
 																					<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23591,6 +26368,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																								<v8:lang>ru</v8:lang>
 																								<v8:content>Задаёт длительность анимации клика.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Anger varaktigheten för klickanimationen.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -23604,6 +26385,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Transparency</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Transparens</v8:content>
 																						</v8:item>
 																					</Title>
 																					<TitleLocation>Top</TitleLocation>
@@ -23619,6 +26404,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Sets the transparency of the click animation.</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Anger transparensen för klickanimationen.</v8:content>
 																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
@@ -23641,6 +26430,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 															<v8:lang>en</v8:lang>
 															<v8:content>HTML and Markdown</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>HTML och Markdown</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -23656,6 +26449,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																</v8:item>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
+																	<v8:content>HTML</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
 																	<v8:content>HTML</v8:content>
 																</v8:item>
 															</Title>
@@ -23675,6 +26472,10 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Make HTML instruction</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Skapa HTML-instruktion</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
@@ -23696,6 +26497,12 @@ For the option to work, you must enable the use of the VanessaExt component.</v8
 Specify console command for snapshots generation in  "Snapshot creating command" field.
 Also use special instructions in the script, see Help info.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad skapas HTML-screencast under scenariokörningen.
+Ange konsolkommando för generering av skärmbilder i fältet "Kommando för skärmbildsskapande".
+Använd även speciella instruktioner i skriptet, se hjälpinformationen.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -23711,6 +26518,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>HTML Directories</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>HTML-kataloger</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -23823,6 +26634,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Каталог HTML инструкций</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>HTML-instruktionskatalog</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -23841,6 +26656,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>HTML Styles</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>HTML-stilar</v8:content>
+																		</v8:item>
 																	</Title>
 																	<ToolTip>
 																		<v8:item>
@@ -23850,6 +26669,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>HTML Styles</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>HTML-stilar</v8:content>
 																		</v8:item>
 																	</ToolTip>
 																	<Behavior>Collapsible</Behavior>
@@ -23867,6 +26690,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Design option</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Designalternativ</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTip>
@@ -23877,6 +26704,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>CSS style design options</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>CSS-stildesignalternativ</v8:content>
 																				</v8:item>
 																			</ToolTip>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -23895,6 +26726,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Screencast without CSS</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Screencast utan CSS</v8:content>
+																							</v8:item>
 																						</Presentation>
 																						<Value xsi:type="xs:decimal">1</Value>
 																					</xr:Value>
@@ -23912,6 +26747,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Screencast with CSS</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Screencast med CSS</v8:content>
+																							</v8:item>
 																						</Presentation>
 																						<Value xsi:type="xs:decimal">2</Value>
 																					</xr:Value>
@@ -23928,6 +26767,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																							<v8:item>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>3D Carousel</v8:content>
+																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>3D-karusell</v8:content>
 																							</v8:item>
 																						</Presentation>
 																						<Value xsi:type="xs:decimal">3</Value>
@@ -23947,6 +26790,11 @@ Also use special instructions in the script, see Help info.</v8:content>
 																						<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;3D Carousel variant - adapted for both PC and mobile
 Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/watch?v=dMmjG97nJ_w&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;3D Carousel-variant - anpassad för både dator och mobil
+Detaljer &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/watch?v=dMmjG97nJ_w&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -23963,6 +26811,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Custom CSS</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Anpassad CSS</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ToolTip>
 																				<v8:item>
@@ -23972,6 +26824,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Custom CSS</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Anpassad CSS</v8:content>
 																				</v8:item>
 																			</ToolTip>
 																			<Group>Vertical</Group>
@@ -23989,6 +26845,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Style File</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Stilfil</v8:content>
+																						</v8:item>
 																					</Title>
 																					<ToolTip>
 																						<v8:item>
@@ -23998,6 +26858,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Style File</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Stilfil</v8:content>
 																						</v8:item>
 																					</ToolTip>
 																					<Group>AlwaysHorizontal</Group>
@@ -24016,6 +26880,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																									<v8:lang>en</v8:lang>
 																									<v8:content>CSS file</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>CSS-fil</v8:content>
+																								</v8:item>
 																							</Title>
 																							<TitleLocation>Top</TitleLocation>
 																							<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -24031,6 +26899,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Style File</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Stilfil</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -24051,6 +26923,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Open the HTML Style Editor</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Öppna HTML-stilredigeraren</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ExtendedTooltip name="ОткрытьРедакторHTMLРасширеннаяПодсказка" id="3771"/>
 																						</Button>
@@ -24065,6 +26941,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Save The Standard HTML Layout</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Spara standard HTML-layout</v8:content>
 																								</v8:item>
 																							</Title>
 																							<ExtendedTooltip name="СохранитьСтандартныйМакетHTMLРасширеннаяПодсказка" id="4000"/>
@@ -24081,6 +26961,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Speech generation</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Talgenerering</v8:content>
+																						</v8:item>
 																					</Title>
 																					<ToolTip>
 																						<v8:item>
@@ -24090,6 +26974,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>HTML voice acting</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>HTML-röstning</v8:content>
 																						</v8:item>
 																					</ToolTip>
 																					<Group>Vertical</Group>
@@ -24110,6 +26998,10 @@ Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/wat
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Voice the steps of the instruction</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Läs upp instruktionens steg</v8:content>
+																								</v8:item>
 																							</Title>
 																							<TitleLocation>Right</TitleLocation>
 																							<ToolTipRepresentation>Button</ToolTipRepresentation>
@@ -24129,6 +27021,12 @@ Text playback starts when you click on the step image.</v8:content>
 &lt;link https://developer.mozilla.org/ru/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API#%D1%81%D0%B8%D0%BD%D1%82%D0%B5%D0%B7_%D1%80%D0%B5%D1%87%D0%B8&gt;Подробнее
 &lt;/&gt;Воспроизведение текста начинается при клике на картинку шага.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Talsyntesteknik inbyggd i webbläsare används. Talsyntes (text-till-tal eller tts) innebär att den syntetiserade texten i applikationen tas emot och återges som tal.
+&lt;link https://developer.mozilla.org/ru/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API&gt;Mer detaljerat&lt;/&gt; 
+Textuppspelning startar när du klickar på stegbilden.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																							<Events>
@@ -24145,6 +27043,10 @@ Text playback starts when you click on the step image.</v8:content>
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Voice tempo</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Rösttempo</v8:content>
 																								</v8:item>
 																							</Title>
 																							<TitleLocation>Top</TitleLocation>
@@ -24171,6 +27073,10 @@ Text playback starts when you click on the step image.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Voice range</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Röstomfång</v8:content>
+																								</v8:item>
 																							</Title>
 																							<TitleLocation>Top</TitleLocation>
 																							<Width>65</Width>
@@ -24195,6 +27101,10 @@ Text playback starts when you click on the step image.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Voice pronunciation</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Röstuttal</v8:content>
+																								</v8:item>
 																							</Title>
 																							<TitleLocation>Top</TitleLocation>
 																							<ChoiceButtonRepresentation>ShowInDropList</ChoiceButtonRepresentation>
@@ -24211,6 +27121,10 @@ Text playback starts when you click on the step image.</v8:content>
 																											</v8:item>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
+																												<v8:content>Microsoft Irina - Russian (Russia)</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
 																												<v8:content>Microsoft Irina - Russian (Russia)</v8:content>
 																											</v8:item>
 																										</Presentation>
@@ -24230,6 +27144,10 @@ Text playback starts when you click on the step image.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Microsoft Mark - English (United States)</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Microsoft Mark - English (United States)</v8:content>
+																											</v8:item>
 																										</Presentation>
 																										<Value xsi:type="xs:string">Microsoft Mark - English (United States)</Value>
 																									</xr:Value>
@@ -24245,6 +27163,10 @@ Text playback starts when you click on the step image.</v8:content>
 																											</v8:item>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
+																												<v8:content>Microsoft Zira - English (United States)</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
 																												<v8:content>Microsoft Zira - English (United States)</v8:content>
 																											</v8:item>
 																										</Presentation>
@@ -24264,6 +27186,10 @@ Text playback starts when you click on the step image.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Microsoft David - English (United States)</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Microsoft David - English (United States)</v8:content>
+																											</v8:item>
 																										</Presentation>
 																										<Value xsi:type="xs:string">Microsoft David - English (United States)</Value>
 																									</xr:Value>
@@ -24279,6 +27205,10 @@ Text playback starts when you click on the step image.</v8:content>
 																											</v8:item>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
+																												<v8:content>Microsoft Pavel - Russian (Russia)</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
 																												<v8:content>Microsoft Pavel - Russian (Russia)</v8:content>
 																											</v8:item>
 																										</Presentation>
@@ -24298,6 +27228,10 @@ Text playback starts when you click on the step image.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Google UK English Female</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Google UK English Female</v8:content>
+																											</v8:item>
 																										</Presentation>
 																										<Value xsi:type="xs:string">Google UK English Female</Value>
 																									</xr:Value>
@@ -24315,6 +27249,10 @@ Text playback starts when you click on the step image.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Google UK English Male</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Google UK English Male</v8:content>
+																											</v8:item>
 																										</Presentation>
 																										<Value xsi:type="xs:string">Google UK English Male</Value>
 																									</xr:Value>
@@ -24330,6 +27268,10 @@ Text playback starts when you click on the step image.</v8:content>
 																											</v8:item>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
+																												<v8:content>Google русский</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
 																												<v8:content>Google русский</v8:content>
 																											</v8:item>
 																										</Presentation>
@@ -24358,6 +27300,10 @@ Text playback starts when you click on the step image.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Markdown</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Markdown</v8:content>
+																</v8:item>
 															</Title>
 															<ToolTip>
 																<v8:item>
@@ -24367,6 +27313,10 @@ Text playback starts when you click on the step image.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Markdown instructions</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Markdown-instruktioner</v8:content>
 																</v8:item>
 															</ToolTip>
 															<Group>Vertical</Group>
@@ -24385,6 +27335,10 @@ Text playback starts when you click on the step image.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Make Markdown instruction</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Skapa Markdown-instruktion</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Right</TitleLocation>
@@ -24405,6 +27359,12 @@ Text playback starts when you click on the step image.</v8:content>
 																				<v8:content>If the checkbox is on, MarkDown screencast will be created during scenario execution.
 Specify console command for snapshots generation in  "Snapshot creating command" field or the screenshots flag is set by the "VanessaExt" component".
 Also use special instructions in the script, see Help info.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om kryssrutan är aktiverad skapas Markdown-screencast under scenariokörningen.
+Ange konsolkommando för generering av skärmbilder i fältet "Kommando för skärmbildsskapande" eller aktivera skärmbildsflaggan via "VanessaExt"-komponenten.
+Använd även speciella instruktioner i skriptet, se hjälpinformationen.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -24516,6 +27476,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Каталог Markdown инструкций</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Markdown-instruktionskatalog</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -24534,6 +27498,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>General</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Allmänt</v8:content>
+																</v8:item>
 															</Title>
 															<ToolTip>
 																<v8:item>
@@ -24543,6 +27511,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>General instruction settings</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Allmänna instruktionsinställningar</v8:content>
 																</v8:item>
 															</ToolTip>
 															<Group>Vertical</Group>
@@ -24561,6 +27533,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>General first line</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Allmänt första raden</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<Representation>None</Representation>
@@ -24576,6 +27552,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>General first row left column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allmänt första raden vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -24595,6 +27575,10 @@ Also use special instructions in the script, see Help info.</v8:content>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Auto numbering of steps of instructions</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Autonumrering av instruktionssteg</v8:content>
+																						</v8:item>
 																					</Title>
 																					<TitleLocation>Right</TitleLocation>
 																					<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -24612,6 +27596,11 @@ To ensure that leading zeros are not lost when exporting from MD format, the tex
 																								<v8:content>Добавляет авто нумерацию в начало текста описания шага. 
 Для того, чтобы лидирующие нули не терялись при экспорте из MD формата, текст записывается в блок кода.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Lägger till autonumrering i början av stegbeskrivningstexten.
+För att säkerställa att inledande nollor inte förloras vid export från MD-format skrivs texten till kodblocket.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</CheckBoxField>
@@ -24626,6 +27615,10 @@ To ensure that leading zeros are not lost when exporting from MD format, the tex
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>General first row right column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allmänt första raden höger kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Representation>None</Representation>
@@ -24654,6 +27647,13 @@ If you need to take only one screenshot for a group of steps, you can specify th
 Чтобы для  одной группы шагов сделать несколько скриншотов нужно использовать тег @screenshot перед нужными шагами.
 Если нужно сделать только один скриншот для группы шагов, то можно указать тег @screenshot только один раз перед нужным шагом.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Aktiverar läget när en grupp steg i ett skript tolkas som ett steg i en textinstruktion.
+Om inga ytterligare taggar anges tas skärmbilden efter att det sista steget i gruppen har slutförts.
+För att ta flera skärmbilder för en grupp steg behöver du använda taggen @screenshot före de nödvändiga stegen.
+Om du bara behöver ta en skärmbild för en grupp steg kan du ange taggen @screenshot bara en gång före det önskade steget.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</CheckBoxField>
@@ -24671,6 +27671,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																			<v8:lang>en</v8:lang>
 																			<v8:content>General second line</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Allmänt andra raden</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<Representation>None</Representation>
@@ -24686,6 +27690,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>General second row left column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allmänt andra raden vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -24710,6 +27718,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																								<v8:lang>ru</v8:lang>
 																								<v8:content>Если флаг установлен, то в текстовую инструкцию будет добавлена информация с названием фичи.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Om flaggan är satt läggs information med feature-namnet till i textinstruktionen.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</CheckBoxField>
@@ -24724,6 +27736,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>General second row right column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Allmänt andra raden höger kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Representation>None</Representation>
@@ -24746,6 +27762,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																								<v8:lang>en</v8:lang>
 																								<v8:content>If the flag is set, then information with the name of the script will be added to the text instruction.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Om flaggan är satt läggs information med skriptnamnet till i textinstruktionen.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</CheckBoxField>
@@ -24767,6 +27787,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 															<v8:lang>en</v8:lang>
 															<v8:content>Audio</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Ljud</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -24776,6 +27800,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Audio</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Ljud</v8:content>
 														</v8:item>
 													</ToolTip>
 													<ToolTipRepresentation>None</ToolTipRepresentation>
@@ -24795,6 +27823,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																	<v8:lang>en</v8:lang>
 																	<v8:content>General</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Allmänt</v8:content>
+																</v8:item>
 															</Title>
 															<ToolTipRepresentation>ShowTop</ToolTipRepresentation>
 															<Group>Vertical</Group>
@@ -24811,6 +27843,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																		<v8:lang>en</v8:lang>
 																		<v8:content>See &lt;link https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/FAQ/MakeAutoVideo.md&gt;here&lt;/&gt; for more information about settings for voice acting of the text by the announcer.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Se &lt;link https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/FAQ/MakeAutoVideo.md&gt;här&lt;/&gt; för mer information om inställningar för textuppsläsning av speakern.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<ChildItems>
@@ -24823,6 +27859,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group audio shared first line</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp ljud delad första raden</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
@@ -24839,6 +27879,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Audio Group Common First Row Left Column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Ljudgrupp gemensam första raden vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -24864,6 +27908,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																								<v8:lang>ru</v8:lang>
 																								<v8:content>Включает озвучку выполнения сценария согласно заданным настройкам голоса диктора.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Inkluderar röstning av skriptkörningen enligt de angivna inställningarna för speakerrösten.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																					<Events>
@@ -24881,6 +27929,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Audio Group Common First Row Right Column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Ljudgrupp gemensam första raden höger kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Representation>None</Representation>
@@ -24904,6 +27956,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																								<v8:lang>ru</v8:lang>
 																								<v8:content>Включает режим, когда по умолчанию каждая группа шагов первого уровня в сценарии будет конвертироваться в один шаг в автоинструкции.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Aktiverar läget när varje första nivåns grupp av scenariosteg konverteras till ett steg i automanualen.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</CheckBoxField>
@@ -24921,6 +27977,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group audio shared second line</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp ljud delad andra raden</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<Representation>None</Representation>
@@ -24936,6 +27996,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Audio group shared second row left column</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Ljudgrupp delad andra raden vänster kolumn</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Width>50</Width>
@@ -24954,6 +28018,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Temporary files directory</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Katalog för tillfälliga filer</v8:content>
 																						</v8:item>
 																					</Title>
 																					<TitleLocation>Top</TitleLocation>
@@ -24982,6 +28050,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Voiceover by announcer</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Röstinspelning av speaker</v8:content>
 																</v8:item>
 															</Title>
 															<ToolTip>
@@ -25086,6 +28158,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Setting up voice acting</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Konfigurera röstning</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Group>AlwaysHorizontal</Group>
 																	<Representation>None</Representation>
@@ -25101,6 +28177,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Internal voicing</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Intern röstning</v8:content>
 																				</v8:item>
 																			</Title>
 																			<Group>Vertical</Group>
@@ -25118,6 +28198,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Voice acting type</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Röstningstyp</v8:content>
 																						</v8:item>
 																					</Title>
 																					<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -25137,6 +28221,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																										<v8:lang>en</v8:lang>
 																										<v8:content>1C</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>1C</v8:content>
+																									</v8:item>
 																								</Presentation>
 																								<Value xsi:type="xs:decimal">4</Value>
 																							</xr:Value>
@@ -25152,6 +28240,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																									</v8:item>
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
+																										<v8:content>Microsoft TTS</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
 																										<v8:content>Microsoft TTS</v8:content>
 																									</v8:item>
 																								</Presentation>
@@ -25173,6 +28265,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																									</v8:item>
 																									<v8:item>
 																										<v8:lang>ro</v8:lang>
+																										<v8:content>Yandex SpeechKit</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
 																										<v8:content>Yandex SpeechKit</v8:content>
 																									</v8:item>
 																								</Presentation>
@@ -25200,6 +28296,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																										<v8:lang>ro</v8:lang>
 																										<v8:content>Amazon Polly</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Amazon Polly</v8:content>
+																									</v8:item>
 																								</Presentation>
 																								<Value xsi:type="xs:decimal">2</Value>
 																							</xr:Value>
@@ -25215,6 +28315,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																									</v8:item>
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
+																										<v8:content>Sber TTS</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
 																										<v8:content>Sber TTS</v8:content>
 																									</v8:item>
 																								</Presentation>
@@ -25234,6 +28338,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Another TTS engine</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Annan TTS-motor</v8:content>
+																									</v8:item>
 																								</Presentation>
 																								<Value xsi:type="xs:decimal">-1</Value>
 																							</xr:Value>
@@ -25251,6 +28359,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Specifies the narrator's voice.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Anger berättarens röst.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																					<Events>
@@ -25267,6 +28379,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Voice settings pages</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Sidor för röstinställningar</v8:content>
+																						</v8:item>
 																					</Title>
 																					<PagesRepresentation>None</PagesRepresentation>
 																					<ExtendedTooltip name="СтраницыНастроекОзвучанияРасширеннаяПодсказка" id="2080"/>
@@ -25281,6 +28397,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Voiceover from 1C</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Röstinspelning från 1C</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ExtendedTooltip name="ГруппаОзвучкаОт1СРасширеннаяПодсказка" id="4075"/>
 																							<ChildItems>
@@ -25293,6 +28413,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Group 1C TTS First line</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Grupp 1C TTS Första raden</v8:content>
 																										</v8:item>
 																									</Title>
 																									<Group>AlwaysHorizontal</Group>
@@ -25309,6 +28433,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group 1C TTS First row left column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp 1C TTS Första raden vänster kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Width>50</Width>
@@ -25333,6 +28461,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																																<v8:lang>en</v8:lang>
 																																<v8:content>Login for authorization in the speech synthesis service</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>Inloggning för auktorisering i talsyntestjänsten</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																												</InputField>
@@ -25347,6 +28479,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group 1C TTS First row right column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp 1C TTS Första raden höger kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Representation>None</Representation>
@@ -25388,6 +28524,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																																<v8:lang>ru</v8:lang>
 																																<v8:content>Голос для генерации речи в сервисе</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>Röst för talgenerering i tjänsten</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																												</InputField>
@@ -25405,6 +28545,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Group 1C TTS Second line</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Grupp 1C TTS Andra raden</v8:content>
+																										</v8:item>
 																									</Title>
 																									<Group>AlwaysHorizontal</Group>
 																									<Representation>NormalSeparation</Representation>
@@ -25420,6 +28564,10 @@ If you need to take only one screenshot for a group of steps, you can specify th
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group 1C TTS Second row left column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp 1C TTS Andra raden vänster kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Width>50</Width>
@@ -25446,6 +28594,11 @@ The password is specified in the text file.</v8:content>
 																																<v8:content>Пароль для авторизации в сервисе синтеза речи.
 Пароль указывается в текстовом файле.</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>Lösenord för auktorisering i talsyntestjänsten.
+Lösenordet anges i textfilen.</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																													<Events>
@@ -25463,6 +28616,10 @@ The password is specified in the text file.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group 1C TTS Second row right column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp 1C TTS Andra raden höger kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Representation>None</Representation>
@@ -25490,6 +28647,11 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																																<v8:content>Скорость (темп) синтезированной речи.
 Скорость речи задается дробным числом в диапазоне от 0.8 до 2.</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>Hastighet (tempo) för syntetiserat tal.
+Talhastigheten anges som ett decimaltal i intervallet 0,8 till 2.</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																													<Events>
@@ -25510,6 +28672,10 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Group 1C TTS Third line</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Grupp 1C TTS Tredje raden</v8:content>
+																										</v8:item>
 																									</Title>
 																									<Group>AlwaysHorizontal</Group>
 																									<Representation>NormalSeparation</Representation>
@@ -25525,6 +28691,10 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group 1C TTS Third row left column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp 1C TTS Tredje raden vänster kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Width>50</Width>
@@ -25550,6 +28720,10 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group 1C TTS Third row right column</v8:content>
 																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp 1C TTS Tredje raden höger kolumn</v8:content>
+																												</v8:item>
 																											</Title>
 																											<Representation>None</Representation>
 																											<ShowTitle>false</ShowTitle>
@@ -25569,6 +28743,10 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Microsoft TTS</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Microsoft TTS</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ExtendedTooltip name="ГруппаMicrosoftTTSРасширеннаяПодсказка" id="1964"/>
 																							<ChildItems>
@@ -25582,6 +28760,10 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>TTS command</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>TTS-kommando</v8:content>
 																										</v8:item>
 																									</Title>
 																									<TitleLocation>Top</TitleLocation>
@@ -25601,6 +28783,11 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																												<v8:lang>en</v8:lang>
 																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;The console command to be used when converting text to speech.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;The &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link http://www.cross-plus-a.ru/bconsole.html&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;balabolka_console&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; program is used.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Konsolkommandot som ska användas vid konvertering av text till tal.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Programmet &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link http://www.cross-plus-a.ru/bconsole.html&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;balabolka_console&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; används.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -25712,6 +28899,11 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Specifies which voice will be used for voice acting. It is allowed to indicate not the full name of the voice in the system, but only a part, for example "Elena".&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;You will need to install &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.microsoft.com/en-us/download/details.aspx?id=27225&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Microsoft Speech Platform x32&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; and&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.microsoft.com/en-us/download/details.aspx?id=27224&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; Server Runtime Languages&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Anger vilken röst som ska användas för uppsläsning. Det är tillåtet att ange inte hela röstnamnet i systemet, utan bara en del, till exempel "Elena".&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Du behöver installera &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.microsoft.com/en-us/download/details.aspx?id=27225&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Microsoft Speech Platform x32&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; och&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.microsoft.com/en-us/download/details.aspx?id=27224&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt; Server Runtime Languages&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</InputField>
@@ -25738,6 +28930,11 @@ Speech speed is specified by a fractional number in the range from 0.8 to 2.</v8
 																												<v8:content>Narrator's speech speed.
 Value range is from -10 to 10.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Berättarens talhastighet.
+Värdeintervallet är från -10 till 10.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</InputField>
@@ -25757,6 +28954,10 @@ Value range is from -10 to 10.</v8:content>
 																									<v8:lang>ro</v8:lang>
 																									<v8:content>Yandex TTS</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Yandex TTS</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ExtendedTooltip name="ГруппаYandexTTSРасширеннаяПодсказка" id="1966"/>
 																							<ChildItems>
@@ -25769,6 +28970,10 @@ Value range is from -10 to 10.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>yandex TTS group First line</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Yandex TTS-grupp Första raden</v8:content>
 																										</v8:item>
 																									</Title>
 																									<Group>AlwaysHorizontal</Group>
@@ -25785,6 +28990,10 @@ Value range is from -10 to 10.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group yandex TTS First row left column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp Yandex TTS Första raden vänster kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Width>50</Width>
@@ -25814,6 +29023,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Russian (ru-RU)</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Russian (ru-RU)</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">ru-RU</Value>
 																															</xr:Value>
@@ -25831,6 +29044,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>English (en-US)</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>English (en-US)</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">en-US</Value>
 																															</xr:Value>
@@ -25846,6 +29063,10 @@ Value range is from -10 to 10.</v8:content>
 																																	</v8:item>
 																																	<v8:item>
 																																		<v8:lang>en</v8:lang>
+																																		<v8:content>Turkish (tr-TR)</v8:content>
+																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
 																																		<v8:content>Turkish (tr-TR)</v8:content>
 																																	</v8:item>
 																																</Presentation>
@@ -25867,6 +29088,11 @@ Value range is from -10 to 10.</v8:content>
 																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Sets the language in which the speaker will speak. Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;To control accent and pronunciation, see &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Anger språket som speakern ska tala på. Detaljer &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;För att styra accent och uttal, se &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																												</InputField>
@@ -25881,6 +29107,10 @@ Value range is from -10 to 10.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>yandex TTS group First row right column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Yandex TTS-grupp Första raden höger kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Representation>None</Representation>
@@ -25908,6 +29138,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Alice</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Alice</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">alyss</Value>
 																															</xr:Value>
@@ -25923,6 +29157,10 @@ Value range is from -10 to 10.</v8:content>
 																																	</v8:item>
 																																	<v8:item>
 																																		<v8:lang>en</v8:lang>
+																																		<v8:content>Jane (jane)</v8:content>
+																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
 																																		<v8:content>Jane (jane)</v8:content>
 																																	</v8:item>
 																																</Presentation>
@@ -25942,6 +29180,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Oksana</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Oksana</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">oksana</Value>
 																															</xr:Value>
@@ -25957,6 +29199,10 @@ Value range is from -10 to 10.</v8:content>
 																																	</v8:item>
 																																	<v8:item>
 																																		<v8:lang>en</v8:lang>
+																																		<v8:content>Omazh</v8:content>
+																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
 																																		<v8:content>Omazh</v8:content>
 																																	</v8:item>
 																																</Presentation>
@@ -25976,6 +29222,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Zahar (zahar)</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Zahar (zahar)</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">zahar</Value>
 																															</xr:Value>
@@ -25991,6 +29241,10 @@ Value range is from -10 to 10.</v8:content>
 																																	</v8:item>
 																																	<v8:item>
 																																		<v8:lang>en</v8:lang>
+																																		<v8:content>Ermil (ermil)</v8:content>
+																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
 																																		<v8:content>Ermil (ermil)</v8:content>
 																																	</v8:item>
 																																</Presentation>
@@ -26010,6 +29264,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Alena</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Alena</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">alena</Value>
 																															</xr:Value>
@@ -26025,6 +29283,10 @@ Value range is from -10 to 10.</v8:content>
 																																	</v8:item>
 																																	<v8:item>
 																																		<v8:lang>en</v8:lang>
+																																		<v8:content>Filipp</v8:content>
+																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
 																																		<v8:content>Filipp</v8:content>
 																																	</v8:item>
 																																</Presentation>
@@ -26046,6 +29308,11 @@ Value range is from -10 to 10.</v8:content>
 																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Sets the voice for the announcer to speak. Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;To control accent and pronunciation, see &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Anger rösten för speakern. Detaljer &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;För att styra accent och uttal, se &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																												</InputField>
@@ -26063,6 +29330,10 @@ Value range is from -10 to 10.</v8:content>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Yandex TTS group second line</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Yandex TTS-grupp andra raden</v8:content>
+																										</v8:item>
 																									</Title>
 																									<Group>AlwaysHorizontal</Group>
 																									<Representation>NormalSeparation</Representation>
@@ -26078,6 +29349,10 @@ Value range is from -10 to 10.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Group yandex TTSSecond row left column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Grupp Yandex TTS Andra raden vänster kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Width>50</Width>
@@ -26107,6 +29382,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Joyful</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Glad</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">good</Value>
 																															</xr:Value>
@@ -26124,6 +29403,10 @@ Value range is from -10 to 10.</v8:content>
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Annoyed</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Irriterad</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:string">evil</Value>
 																															</xr:Value>
@@ -26139,6 +29422,10 @@ Value range is from -10 to 10.</v8:content>
 																																	</v8:item>
 																																	<v8:item>
 																																		<v8:lang>en</v8:lang>
+																																		<v8:content>Neutral (neutral)</v8:content>
+																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
 																																		<v8:content>Neutral (neutral)</v8:content>
 																																	</v8:item>
 																																</Presentation>
@@ -26160,6 +29447,11 @@ Value range is from -10 to 10.</v8:content>
 																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Sets the emotion with which the announcer will speak. Details &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;To control accent and pronunciation, see &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Anger känslan med vilken speakern ska tala. Detaljer &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://cloud.yandex.ru/docs/speechkit/tts/request&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;För att styra accent och uttal, se &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																												</InputField>
@@ -26174,6 +29466,10 @@ Value range is from -10 to 10.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>yandex TTS group second row right column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Yandex TTS-grupp andra raden höger kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Representation>None</Representation>
@@ -26203,6 +29499,11 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																																<v8:content>Скорость (темп) синтезированной речи.
 Скорость речи задается дробным числом в диапазоне от 0.1 до 3.0.</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>Hastigheten (tempot) för syntetiserat tal.
+Talhastigheten anges som ett decimaltal i intervallet 0,1 till 3,0.</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																													<Events>
@@ -26223,6 +29524,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Yandex TTS group third line</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Yandex TTS-grupp tredje raden</v8:content>
+																										</v8:item>
 																									</Title>
 																									<Group>AlwaysHorizontal</Group>
 																									<Representation>None</Representation>
@@ -26238,6 +29543,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>yandex TTS group third row left column</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Yandex TTS-grupp tredje raden vänster kolumn</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Width>50</Width>
@@ -26257,6 +29566,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																															<v8:lang>en</v8:lang>
 																															<v8:content>Request option</v8:content>
 																														</v8:item>
+																														<v8:item>
+																															<v8:lang>sv</v8:lang>
+																															<v8:content>Begäransalternativ</v8:content>
+																														</v8:item>
 																													</Title>
 																													<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																													<RadioButtonType>Auto</RadioButtonType>
@@ -26272,6 +29585,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																																	</v8:item>
 																																	<v8:item>
 																																		<v8:lang>en</v8:lang>
+																																		<v8:content>API</v8:content>
+																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
 																																		<v8:content>API</v8:content>
 																																	</v8:item>
 																																</Presentation>
@@ -26291,6 +29608,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																																		<v8:lang>en</v8:lang>
 																																		<v8:content>Web interface</v8:content>
 																																	</v8:item>
+																																	<v8:item>
+																																		<v8:lang>sv</v8:lang>
+																																		<v8:content>Webbgränssnitt</v8:content>
+																																	</v8:item>
 																																</Presentation>
 																																<Value xsi:type="xs:decimal">1</Value>
 																															</xr:Value>
@@ -26307,6 +29628,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																															<v8:item>
 																																<v8:lang>ru</v8:lang>
 																																<v8:content>Определяет как будут получены файлы озвучки: через официальное API или через бесплатный интерфейс. Рекомендуемое значение - через официальное API.</v8:content>
+																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>Bestämmer hur ljudfilerna tas emot: via det officiella API:et eller via det fria gränssnittet. Det rekommenderade värdet är via det officiella API:et.</v8:content>
 																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
@@ -26328,6 +29653,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Authorization</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Auktorisering</v8:content>
+																										</v8:item>
 																									</Title>
 																									<ToolTip>
 																										<v8:item>
@@ -26337,6 +29666,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Group OR</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Grupp ELLER</v8:content>
 																										</v8:item>
 																									</ToolTip>
 																									<Group>Vertical</Group>
@@ -26375,6 +29708,17 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;(Directory ID - b1gheo81t4a6eaafe5vd)&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;link https://cloud.yandex.ru/docs/resource-manager/operations/folder/get-id&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Retrieving a Directory ID&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Den sista delen av sökvägen i adressfältet i webbläsaren. https://console.cloud.yandex.ru/folders/Katalog-ID&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Gör följande:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;1. I huvudfönstret för Yandex.Cloud, klicka på länken "Gå till aktuell katalog".&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;2. Kopiera den sista delen av sökvägen från adressfältet&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Exempel:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;https://console.cloud.yandex.ru/folders/b1gheo81t4a6eaafe5vd&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;(Katalog-ID - b1gheo81t4a6eaafe5vd)&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;link https://cloud.yandex.ru/docs/resource-manager/operations/folder/get-id&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Hämta ett katalog-ID&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
 																										</InputField>
@@ -26387,6 +29731,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Token or Api Key</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Token eller Api-nyckel</v8:content>
 																												</v8:item>
 																											</Title>
 																											<Group>AlwaysHorizontal</Group>
@@ -26423,6 +29771,15 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;3. Save it to a text file;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;4. Specify the path to the text file with the token.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;OAuth-token används i autentiseringsprocessen i Yandex.Cloud&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;För att få en OAuth-token behöver du:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;1. Följ länken https://cloud.yandex.ru/docs/iam/concepts/authorization/oauth-token;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;2. Generera en token;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;3. Spara den i en textfil;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;4. Ange sökvägen till textfilen med token.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																													<Events>
@@ -26439,6 +29796,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																														<v8:item>
 																															<v8:lang>en</v8:lang>
 																															<v8:content>or</v8:content>
+																														</v8:item>
+																														<v8:item>
+																															<v8:lang>sv</v8:lang>
+																															<v8:content>eller</v8:content>
 																														</v8:item>
 																													</Title>
 																													<ContextMenu name="ДекорацияЗаписьВидеоYandexTTSИлиКонтекстноеМеню" id="3241"/>
@@ -26465,6 +29826,13 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;If specified, then authorization will be through it, if not, it will be through the Token&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 </v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;API-nyckeln används i autentiseringsprocessen i Yandex.Cloud&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;link https://cloud.yandex.ru/docs/iam/operations/api-key/create&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;https://cloud.yandex.ru/docs/iam/operations/api-key/create&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om den anges sker auktorisering via den, annars via Token&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+</v8:content>
+																															</v8:item>
 																														</Title>
 																													</ExtendedTooltip>
 																												</InputField>
@@ -26484,6 +29852,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Group amazon TTS</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Grupp Amazon TTS</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ToolTip>
 																								<v8:item>
@@ -26493,6 +29865,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Group amazon TTS</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Grupp Amazon TTS</v8:content>
 																								</v8:item>
 																							</ToolTip>
 																							<ExtendedTooltip name="ГруппаAmazonTTSРасширеннаяПодсказка" id="2105"/>
@@ -26749,6 +30125,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>See the correspondence of language and voice &lt;link https://docs.aws.amazon.com/en_us/polly/latest/dg/voicelist.html&gt;here&lt;/&gt;.</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Se överensstämmelsen mellan språk och röst &lt;link https://docs.aws.amazon.com/en_us/polly/latest/dg/voicelist.html&gt;här&lt;/&gt;.</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -27246,6 +30626,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																												<v8:lang>en</v8:lang>
 																												<v8:content>See the correspondence of language and voice &lt;link https://docs.aws.amazon.com/en_us/polly/latest/dg/voicelist.html&gt;here&lt;/&gt;.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Se överensstämmelsen mellan språk och röst &lt;link https://docs.aws.amazon.com/en_us/polly/latest/dg/voicelist.html&gt;här&lt;/&gt;.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</InputField>
@@ -27286,6 +30670,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																												<v8:lang>en</v8:lang>
 																												<v8:content>See the options for the value for the "Engine" field &lt;link https://docs.aws.amazon.com/en_us/polly/latest/dg/voicelist.html&gt;here&lt;/&gt;.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Se alternativen för värdet i fältet "Engine" &lt;link https://docs.aws.amazon.com/en_us/polly/latest/dg/voicelist.html&gt;här&lt;/&gt;.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</InputField>
@@ -27305,6 +30693,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																												<v8:lang>ru</v8:lang>
 																												<v8:content>В поле указывается параметр регион. Значение по умолчанию: us-east-1.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Fältet anger regionparametern. Standard är us-east-1.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</InputField>
@@ -27323,6 +30715,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Amazon cloud access key.</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Amazon-molnåtkomstnyckel.</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -27345,6 +30741,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																												<v8:lang>en</v8:lang>
 																												<v8:content>The file where Amazon cloud private key is stored.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Filen där Amazons molnprivatnyckel lagras.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																									<Events>
@@ -27362,6 +30762,10 @@ Speech rate is specified as a fractional number in the range from 0.1 to 3.0.</v
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Group other TTS engine</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Grupp annan TTS-motor</v8:content>
 																								</v8:item>
 																							</Title>
 																							<ExtendedTooltip name="ГруппаДругойДвижокTTSРасширеннаяПодсказка" id="2994"/>
@@ -27402,6 +30806,19 @@ VoiceParams - additional voice parameters specified in the feature file using ad
 
 The method should return the path to the mp3 file.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Låter dig generera röstinspelningar för ett steg med extern bearbetning. Bearbetningen ska innehålla en exportmetod i huvudformuläret:
+GetMp3File (Vanessa, VideoParams, Text, FileName, VoiceParams)
+Där:
+Vanessa - Vanessa Automation kontextramverk
+VideoParams - Struktur med videoinspelningsparametrar
+Text - texten som ska läsas upp
+FileName - namnet på det aktuella videoklippet
+VoiceParams - ytterligare röstparametrar angivna i feature-filen med hjälp av ytterligare direktiv
+
+Metoden ska returnera sökvägen till mp3-filen.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																									<Events>
@@ -27423,6 +30840,10 @@ The method should return the path to the mp3 file.</v8:content>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Settings</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Inställningar</v8:content>
+																										</v8:item>
 																									</Title>
 																									<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																									<RowFilter xsi:nil="true"/>
@@ -27437,6 +30858,10 @@ The method should return the path to the mp3 file.</v8:content>
 																											<v8:item>
 																												<v8:lang>ru</v8:lang>
 																												<v8:content>Позволяет задать произвольный набор настроек для генерации файлов озвучки.</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Låter dig ställa in en godtycklig uppsättning inställningar för att generera röstinspelningar.</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -27476,6 +30901,10 @@ The method should return the path to the mp3 file.</v8:content>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Name</v8:content>
 																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Namn</v8:content>
+																												</v8:item>
 																											</Title>
 																											<EditMode>EnterOnInput</EditMode>
 																											<ContextMenu name="НастройкиДругогоДвижкаTTSИмяКонтекстноеМеню" id="3012"/>
@@ -27491,6 +30920,10 @@ The method should return the path to the mp3 file.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Value</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Värde</v8:content>
 																												</v8:item>
 																											</Title>
 																											<EditMode>EnterOnInput</EditMode>
@@ -27511,6 +30944,10 @@ The method should return the path to the mp3 file.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>SBER parameters</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>SBER-parametrar</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ExtendedTooltip name="ГруппаСберTTSРасширеннаяПодсказка" id="3049"/>
 																							<ChildItems>
@@ -27529,6 +30966,10 @@ The method should return the path to the mp3 file.</v8:content>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Client ID received in Smartmarket studio</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Klient-ID mottaget i Smartmarket studio</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -27549,6 +30990,10 @@ The method should return the path to the mp3 file.</v8:content>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>The second part of client identification in Smartmarket studio</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Den andra delen av klientidentifieringen i Smartmarket studio</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -27572,6 +31017,10 @@ The method should return the path to the mp3 file.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Natali (24 kHz)</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Natali (24 kHz)</v8:content>
+																													</v8:item>
 																												</Presentation>
 																												<Value xsi:type="xs:string">Nec_24000</Value>
 																											</xr:Value>
@@ -27587,6 +31036,10 @@ The method should return the path to the mp3 file.</v8:content>
 																													</v8:item>
 																													<v8:item>
 																														<v8:lang>en</v8:lang>
+																														<v8:content>Natali (8 кГц)</v8:content>
+																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
 																														<v8:content>Natali (8 кГц)</v8:content>
 																													</v8:item>
 																												</Presentation>
@@ -27606,6 +31059,10 @@ The method should return the path to the mp3 file.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Boris (24 kHz)</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Boris (24 kHz)</v8:content>
+																													</v8:item>
 																												</Presentation>
 																												<Value xsi:type="xs:string">Bys_24000</Value>
 																											</xr:Value>
@@ -27621,6 +31078,10 @@ The method should return the path to the mp3 file.</v8:content>
 																													</v8:item>
 																													<v8:item>
 																														<v8:lang>en</v8:lang>
+																														<v8:content>Boris (8 kHz)</v8:content>
+																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
 																														<v8:content>Boris (8 kHz)</v8:content>
 																													</v8:item>
 																												</Presentation>
@@ -27640,6 +31101,10 @@ The method should return the path to the mp3 file.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Marfa (24 kHz)</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Marfa (24 kHz)</v8:content>
+																													</v8:item>
 																												</Presentation>
 																												<Value xsi:type="xs:string">May_24000</Value>
 																											</xr:Value>
@@ -27655,6 +31120,10 @@ The method should return the path to the mp3 file.</v8:content>
 																													</v8:item>
 																													<v8:item>
 																														<v8:lang>en</v8:lang>
+																														<v8:content>Marfa (8 kHz)</v8:content>
+																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
 																														<v8:content>Marfa (8 kHz)</v8:content>
 																													</v8:item>
 																												</Presentation>
@@ -27674,6 +31143,10 @@ The method should return the path to the mp3 file.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Taras (24 kHz)</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Taras (24 kHz)</v8:content>
+																													</v8:item>
 																												</Presentation>
 																												<Value xsi:type="xs:string">Tur_24000</Value>
 																											</xr:Value>
@@ -27689,6 +31162,10 @@ The method should return the path to the mp3 file.</v8:content>
 																													</v8:item>
 																													<v8:item>
 																														<v8:lang>en</v8:lang>
+																														<v8:content>Taras (8 kHz)</v8:content>
+																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
 																														<v8:content>Taras (8 kHz)</v8:content>
 																													</v8:item>
 																												</Presentation>
@@ -27710,6 +31187,11 @@ The method should return the path to the mp3 file.</v8:content>
 																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Sets the voice to generate.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Examples of voices can be found &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://developer.sberdevices.ru/docs/ru/smartservices/synthesize_smartspeech#%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80%D1%8B-%D0%B3%D0%BE%D0%BB%D0%BE%D1%81%D0%BE%D0%B2-%D0%B4%D0%BB%D1%8F-%D1%81%D0%B8%D0%BD%D1%82%D0%B5%D0%B7%D0%B0&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Anger rösten som ska genereras.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Exempel på röster finns &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://developer.sberdevices.ru/docs/ru/smartservices/synthesize_smartspeech#%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80%D1%8B-%D0%B3%D0%BE%D0%BB%D0%BE%D1%81%D0%BE%D0%B2-%D0%B4%D0%BB%D1%8F-%D1%81%D0%B8%D0%BD%D1%82%D0%B5%D0%B7%D0%B0&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</InputField>
@@ -27722,6 +31204,10 @@ The method should return the path to the mp3 file.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>How to get access keys</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Hur man får åtkomstnycklar</v8:content>
 																										</v8:item>
 																									</Title>
 																									<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -27751,6 +31237,17 @@ The method should return the path to the mp3 file.</v8:content>
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;6. Click “Save” and then “Submit for moderation”.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;7. After approving the moderation, you will get access to the "Access" tab, where you can get the client_id and client_secret required for the API to work.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Instruktioner för att få åtkomst till SmartSpeech API (det tar ett par minuter):&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;1. Logga in på SmartMarket Studio https://developers.sber.ru/studio&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;2. I vänsterpanelen, välj eller skapa ett företagsutrymme. Gå igenom företagsverifieringen.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;3. Välj SmartService-projektet.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;4. Ange projektnamnet (valfritt namn du förstår).&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;5. Markera kryssrutan bredvid SmartSpeech och fyll i förfrågan enligt instruktionerna.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;6. Klicka på “Spara” och sedan “Skicka till moderering”.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;7. Efter godkänd moderering får du åtkomst till fliken “Åtkomst”, där du kan hämta client_id och client_secret som krävs för att API:et ska fungera.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</LabelDecoration>
@@ -27763,6 +31260,10 @@ The method should return the path to the mp3 file.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Features of text markup</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Funktioner för textformatering</v8:content>
 																										</v8:item>
 																									</Title>
 																									<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -27790,6 +31291,16 @@ The method should return the path to the mp3 file.</v8:content>
 
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;More details can be found &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://developer.sberdevices.ru/docs/ru/developer_tools/ssml/overview&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;När du markerar text kan du:&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- ange pauser,&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- textersättning vid uttal,&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- lägga till ljudeffekter&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;- ange uttal av förkortningar, etc.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Mer information finns &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://developer.sberdevices.ru/docs/ru/developer_tools/ssml/overview&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</LabelDecoration>
@@ -27809,6 +31320,10 @@ The method should return the path to the mp3 file.</v8:content>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Voice test</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Rösttest</v8:content>
+																				</v8:item>
 																			</Title>
 																			<ToolTip>
 																				<v8:item>
@@ -27818,6 +31333,10 @@ The method should return the path to the mp3 file.</v8:content>
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Group voice test</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Grupp rösttest</v8:content>
 																				</v8:item>
 																			</ToolTip>
 																			<Group>Vertical</Group>
@@ -27832,6 +31351,10 @@ The method should return the path to the mp3 file.</v8:content>
 																						</v8:item>
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
+																							<v8:content>Text</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
 																							<v8:content>Text</v8:content>
 																						</v8:item>
 																					</Title>
@@ -27854,6 +31377,10 @@ The method should return the path to the mp3 file.</v8:content>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Hi, I'm Vanessa!</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Hej, jag är Vanessa!</v8:content>
+																						</v8:item>
 																					</InputHint>
 																					<ContextMenu name="ТекстДляТестаГолосаКонтекстноеМеню" id="2124"/>
 																					<ExtendedTooltip name="ТекстДляТестаГолосаРасширеннаяПодсказка" id="2125">
@@ -27869,6 +31396,11 @@ The method should return the path to the mp3 file.</v8:content>
 																								<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;The text to be spoken.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;To control accent and pronunciation, see &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;here&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Texten som ska läsas upp.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;För att styra accent och uttal, se &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://yandex.ru/dev/dialogs/alice/doc/speech-tuning-docpage/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;här&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -27881,6 +31413,10 @@ The method should return the path to the mp3 file.</v8:content>
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Speak text</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Tala text</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Group>AlwaysHorizontal</Group>
@@ -27902,6 +31438,10 @@ The method should return the path to the mp3 file.</v8:content>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Generates mp3 file with the specified text and runs it for playback by the external component VanessaExt.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Genererar mp3-fil med angiven text och kör den för uppspelning via den externa komponenten VanessaExt.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</Button>
@@ -27918,6 +31458,10 @@ The method should return the path to the mp3 file.</v8:content>
 																									<v8:item>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Generates mp3 file with the specified text and runs it in the default player.</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Genererar mp3-fil med angiven text och kör den i standardspelaren.</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -27939,6 +31483,10 @@ The method should return the path to the mp3 file.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Audio cache</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Ljudcache</v8:content>
 																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
@@ -27970,6 +31518,13 @@ Makes video assembly process faster.
 Reduces external voice generation servises usage.
 Reduces voice generation costs.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar cachning av röstfiler.
+Gör videomonteringsprocessen snabbare.
+Minskar användningen av externa röstgenereringstjänster.
+Minskar kostnaderna för röstgenerering.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -27994,6 +31549,10 @@ Reduces voice generation costs.</v8:content>
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Voice cache files directory.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Katalog för röstcachefiler.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -28207,6 +31766,10 @@ Reduces voice generation costs.</v8:content>
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Список файлов, которые будут использоваться для автозамены произносимого текста.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Lista över filer som kommer att användas för autokorrigering av talad text.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<SearchStringAddition name="ЗаписьВидеоСловарьЗаменСтрокаПоиска" id="1731">
@@ -28245,6 +31808,10 @@ Reduces voice generation costs.</v8:content>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Value</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Värde</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<EditMode>EnterOnInput</EditMode>
@@ -28270,6 +31837,10 @@ Reduces voice generation costs.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Video</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Video</v8:content>
+														</v8:item>
 													</Title>
 													<Group>Vertical</Group>
 													<Behavior>Collapsible</Behavior>
@@ -28287,6 +31858,10 @@ Reduces voice generation costs.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Create video tutorial</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Skapa videohandledning</v8:content>
 																</v8:item>
 															</Title>
 															<TitleLocation>Right</TitleLocation>
@@ -28308,6 +31883,12 @@ Reduces voice generation costs.</v8:content>
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;A video describing the settings is in this &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/watch?v=QSDvDQDLyLk&amp;list=PLalsS95_a3a_m9ieRJgD3XPWCP9goa9GC&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;playlist&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;It is also recommended to read this &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/FAQ/MakeAutoVideo.md&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;FAQ&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Gör det möjligt att skapa videoinstruktioner.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;En video som beskriver inställningarna finns i denna &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://www.youtube.com/watch?v=QSDvDQDLyLk&amp;list=PLalsS95_a3a_m9ieRJgD3XPWCP9goa9GC&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;spellista&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Det rekommenderas också att läsa denna &lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;link https://github.com/Pr-Mex/vanessa-automation/blob/develop/docs/FAQ/MakeAutoVideo.md&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;FAQ&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<Events>
@@ -28324,6 +31905,10 @@ Reduces voice generation costs.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group work with video first line</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp arbete med video första raden</v8:content>
+																</v8:item>
 															</Title>
 															<Group>AlwaysHorizontal</Group>
 															<Representation>None</Representation>
@@ -28339,6 +31924,10 @@ Reduces voice generation costs.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group work with video first line left column</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp arbete med video första raden vänster kolumn</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Width>50</Width>
@@ -28358,6 +31947,10 @@ Reduces voice generation costs.</v8:content>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Video tutorials directory</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Katalog för videohandledningar</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -28374,6 +31967,10 @@ Reduces voice generation costs.</v8:content>
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Directory where will be placed result of assembly videos or animated screencast.</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Katalog där resultatet av videomontering eller animerad screencast placeras.</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -28393,6 +31990,10 @@ Reduces voice generation costs.</v8:content>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Group work with video first row right column</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Grupp arbete med video första raden höger kolumn</v8:content>
+																		</v8:item>
 																	</Title>
 																	<Representation>None</Representation>
 																	<ShowTitle>false</ShowTitle>
@@ -28409,6 +32010,10 @@ Reduces voice generation costs.</v8:content>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Project directory</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Projektkatalog</v8:content>
+																				</v8:item>
 																			</Title>
 																			<TitleLocation>Top</TitleLocation>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -28424,6 +32029,10 @@ Reduces voice generation costs.</v8:content>
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Test project files directory.</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Katalog för testprojektfiler.</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -28445,6 +32054,10 @@ Reduces voice generation costs.</v8:content>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Video settings</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Videoinställningar</v8:content>
+																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
 															<Representation>None</Representation>
@@ -28461,6 +32074,10 @@ Reduces voice generation costs.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Video tutorial type</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Videohandledningstyp</v8:content>
 																		</v8:item>
 																	</Title>
 																	<Group>Horizontal</Group>
@@ -28485,6 +32102,10 @@ Reduces voice generation costs.</v8:content>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Create a video tutorial.</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Skapa en videohandledning.</v8:content>
+																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
 																			<Events>
@@ -28506,6 +32127,10 @@ Reduces voice generation costs.</v8:content>
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Create animated HTML screencast.</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Skapa animerad HTML-screencast.</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -28535,6 +32160,10 @@ Reduces voice generation costs.</v8:content>
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Video tutorial settings</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Inställningar för videohandledning</v8:content>
 																		</v8:item>
 																	</Title>
 																	<HorizontalStretch>true</HorizontalStretch>
@@ -28641,6 +32270,10 @@ Reduces voice generation costs.</v8:content>
 																					<v8:lang>vi</v8:lang>
 																					<v8:content>Cài đặt video</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Videosida</v8:content>
+																				</v8:item>
 																			</ToolTip>
 																			<ExtendedTooltip name="СтраницаВидеоРасширеннаяПодсказка" id="1415"/>
 																			<ChildItems>
@@ -28653,6 +32286,10 @@ Reduces voice generation costs.</v8:content>
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Video buttons</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Videoknappar</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Group>Horizontal</Group>
@@ -28674,6 +32311,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Checks basic commands on video composing and sound.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Kontrollerar grundläggande kommandon för videokomposition och ljud.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</Button>
@@ -28691,6 +32332,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Uploads the settings from Vanessa Automation installation json file. After uploading, it might be required to adjust the settings.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Laddar upp inställningarna från Vanessa Automations installations-json-fil. Efter uppladdning kan det krävas att justera inställningarna.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																						</Button>
@@ -28705,6 +32350,10 @@ Reduces voice generation costs.</v8:content>
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>General</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Allmänt</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Group>Vertical</Group>
@@ -28723,6 +32372,10 @@ Reduces voice generation costs.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Video instruction settings basic second line</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Videoinstruktionsinställningar grundläggande andra raden</v8:content>
+																								</v8:item>
 																							</Title>
 																							<Group>AlwaysHorizontal</Group>
 																							<Representation>None</Representation>
@@ -28738,6 +32391,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Basic video instruction settings second row left column</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Grundläggande videoinstruktionsinställningar andra raden vänster kolumn</v8:content>
 																										</v8:item>
 																									</Title>
 																									<Width>50</Width>
@@ -28764,6 +32421,10 @@ Reduces voice generation costs.</v8:content>
 																																<v8:lang>en</v8:lang>
 																																<v8:content>FFmpeg (Recommended)</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>FFmpeg (Rekommenderad)</v8:content>
+																															</v8:item>
 																														</Presentation>
 																														<Value xsi:type="xs:string">ffmpeg</Value>
 																													</xr:Value>
@@ -28781,6 +32442,10 @@ Reduces voice generation costs.</v8:content>
 																																<v8:lang>en</v8:lang>
 																																<v8:content>VLC media player</v8:content>
 																															</v8:item>
+																															<v8:item>
+																																<v8:lang>sv</v8:lang>
+																																<v8:content>VLC mediaspelare</v8:content>
+																															</v8:item>
 																														</Presentation>
 																														<Value xsi:type="xs:string">vlc</Value>
 																													</xr:Value>
@@ -28797,6 +32462,10 @@ Reduces voice generation costs.</v8:content>
 																													<v8:item>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>If VLC is selected, VLC will be used for video recording. Otherwise, VanessaExt add-in that will call ffmpeg will be used.</v8:content>
+																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Om VLC är valt används VLC för videoinspelning. Annars används VanessaExt-tillägget som anropar ffmpeg.</v8:content>
 																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
@@ -28818,6 +32487,10 @@ Reduces voice generation costs.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Video instruction settings basic first line</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Videoinstruktionsinställningar grundläggande första raden</v8:content>
+																								</v8:item>
 																							</Title>
 																							<Group>AlwaysHorizontal</Group>
 																							<Representation>None</Representation>
@@ -28833,6 +32506,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Video instruction settings basic first row left column</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Videoinstruktionsinställningar grundläggande första raden vänster kolumn</v8:content>
 																										</v8:item>
 																									</Title>
 																									<Width>50</Width>
@@ -28944,6 +32621,10 @@ Reduces voice generation costs.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Sets shots per second number for the recording.</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Anger antal bilder per sekund för inspelningen.</v8:content>
+																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
 																										</InputField>
@@ -28958,6 +32639,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Video instruction settings basic first row right column</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Videoinstruktionsinställningar grundläggande första raden höger kolumn</v8:content>
 																										</v8:item>
 																									</Title>
 																									<Representation>None</Representation>
@@ -29062,6 +32747,10 @@ Reduces voice generation costs.</v8:content>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Directory where files will be saved at the time of compile video instructions.</v8:content>
 																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Katalog där filer sparas vid kompilering av videoinstruktioner.</v8:content>
+																												</v8:item>
 																											</ToolTip>
 																											<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																											<AutoMaxWidth>false</AutoMaxWidth>
@@ -29077,6 +32766,10 @@ Reduces voice generation costs.</v8:content>
 																													<v8:item>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>The directory for temporary files created on video recording and composing. The directory is cleared before each recording!</v8:content>
+																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Katalogen för tillfälliga filer som skapas vid videoinspelning och -komposition. Katalogen rensas före varje inspelning!</v8:content>
 																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
@@ -29098,6 +32791,10 @@ Reduces voice generation costs.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Video instruction settings basic third line</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Videoinstruktionsinställningar grundläggande tredje raden</v8:content>
+																								</v8:item>
 																							</Title>
 																							<Group>AlwaysHorizontal</Group>
 																							<Representation>None</Representation>
@@ -29113,6 +32810,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Video instruction settings basic third row left column</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Videoinstruktionsinställningar grundläggande tredje raden vänster kolumn</v8:content>
 																										</v8:item>
 																									</Title>
 																									<Width>50</Width>
@@ -29149,6 +32850,15 @@ Reduces voice generation costs.</v8:content>
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;If there is a fragment, then it will be taken from the cache.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Setting the flag speeds up video assembly.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om flaggan är satt, när steget körs&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Och videoinfogningen "TextInsert"&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;kontrolleras om det redan finns ett sådant videofragment i cachen.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om det inte finns något fragment i cachen läggs det till där.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Om det finns ett fragment tas det från cachen.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Att sätta flaggan snabbar upp videomonteringen.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
 																											<Events>
@@ -29174,6 +32884,10 @@ Reduces voice generation costs.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Video snippets directory.</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Katalog för videoklipp.</v8:content>
+																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
 																											<Events>
@@ -29196,6 +32910,10 @@ Reduces voice generation costs.</v8:content>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Screen</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Skärm</v8:content>
+																						</v8:item>
 																					</Title>
 																					<Group>Vertical</Group>
 																					<Behavior>Collapsible</Behavior>
@@ -29213,6 +32931,10 @@ Reduces voice generation costs.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Screen parameters frame</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Skärmparametrar ram</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ToolTip>
 																								<v8:item>
@@ -29222,6 +32944,10 @@ Reduces voice generation costs.</v8:content>
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Screen parameters frame</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Skärmparametrar ram</v8:content>
 																								</v8:item>
 																							</ToolTip>
 																							<Group>Horizontal</Group>
@@ -29239,6 +32965,10 @@ Reduces voice generation costs.</v8:content>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Screen parameters indent</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Skärmparametrar indrag</v8:content>
+																										</v8:item>
 																									</Title>
 																									<ToolTip>
 																										<v8:item>
@@ -29248,6 +32978,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Screen parameters indent</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Skärmparametrar indrag</v8:content>
 																										</v8:item>
 																									</ToolTip>
 																									<Group>Vertical</Group>
@@ -29358,6 +33092,10 @@ Reduces voice generation costs.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Sets screen width for the recording. Maximum value is screen width for the current resolution. If the specified value is less than screen width, screen area beginning from upper left corner will be recorded.</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Anger skärmbredden för inspelningen. Maximalt värde är skärmbredden för den aktuella upplösningen. Om det angivna värdet är mindre än skärmbredden spelas skärmområdet från övre vänstra hörnet in.</v8:content>
+																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
 																										</InputField>
@@ -29371,6 +33109,10 @@ Reduces voice generation costs.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>Left indent</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>Vänster indrag</v8:content>
 																												</v8:item>
 																											</Title>
 																											<TitleLocation>Top</TitleLocation>
@@ -29388,6 +33130,10 @@ Reduces voice generation costs.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Sets left indent</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Anger vänster indrag</v8:content>
+																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
 																										</InputField>
@@ -29403,6 +33149,10 @@ Reduces voice generation costs.</v8:content>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Screen parameters sizes</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Skärmparametrar storlekar</v8:content>
+																										</v8:item>
 																									</Title>
 																									<ToolTip>
 																										<v8:item>
@@ -29412,6 +33162,10 @@ Reduces voice generation costs.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Screen parameters sizes</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Skärmparametrar storlekar</v8:content>
 																										</v8:item>
 																									</ToolTip>
 																									<Group>Vertical</Group>
@@ -29522,6 +33276,10 @@ Reduces voice generation costs.</v8:content>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Sets screen height for the recording. Maximum value is screen height for the current resolution. If the specified value is less than screen height, screen area beginning from upper left corner will be recorded.</v8:content>
 																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Anger skärmhöjden för inspelningen. Maximalt värde är skärmhöjden för den aktuella upplösningen. Om det angivna värdet är mindre än skärmhöjden spelas skärmområdet från övre vänstra hörnet in.</v8:content>
+																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
 																										</InputField>
@@ -29535,6 +33293,10 @@ Reduces voice generation costs.</v8:content>
 																												<v8:item>
 																													<v8:lang>en</v8:lang>
 																													<v8:content>top</v8:content>
+																												</v8:item>
+																												<v8:item>
+																													<v8:lang>sv</v8:lang>
+																													<v8:content>topp</v8:content>
 																												</v8:item>
 																											</Title>
 																											<TitleLocation>Top</TitleLocation>
@@ -29551,6 +33313,10 @@ Reduces voice generation costs.</v8:content>
 																													<v8:item>
 																														<v8:lang>en</v8:lang>
 																														<v8:content>Sets top indent</v8:content>
+																													</v8:item>
+																													<v8:item>
+																														<v8:lang>sv</v8:lang>
+																														<v8:content>Anger övre indrag</v8:content>
 																													</v8:item>
 																												</Title>
 																											</ExtendedTooltip>
@@ -29570,6 +33336,10 @@ Reduces voice generation costs.</v8:content>
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Console commands</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Konsolkommandon</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Behavior>Collapsible</Behavior>
@@ -29682,6 +33452,11 @@ Reduces voice generation costs.</v8:content>
 																										<v8:lang>en</v8:lang>
 																										<v8:content>Video running and processing command. Also you can specify a full path to ffmpeg.exe file
 Default: ffmpeg</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Kommando för videokörning och bearbetning. Du kan även ange den fullständiga sökvägen till ffmpeg.exe
+Standard: ffmpeg</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -29811,6 +33586,19 @@ Example:
 Download: &lt;link https://imagemagick.org/script/download.php&gt;https://imagemagick.org/script/download.php&lt;/&gt;
 For versions earlier than 7 during the installation, the following item is required for installation: Install legacy utilities (e. G. Convert)</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Fältet beskriver hur kommandot Convert kommer att anropas.
+För ImageMagick 7, ange helt enkelt "magick convert."
+
+För äldre versioner behöver du ange sökvägen till den körbara filen convert.exe i katalogen med ImageMagick-programmet.
+
+Exempel:
+"C:\Program Files\ImageMagick-X.X.X-Q16\convert.exe"
+
+Nedladdning: &lt;link https://imagemagick.org/script/download.php&gt;https://imagemagick.org/script/download.php&lt;/&gt;
+För versioner äldre än 7 krävs följande alternativ vid installationen: Install legacy utilities (e. G. Convert)</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																							<Events>
@@ -29925,6 +33713,10 @@ For versions earlier than 7 during the installation, the following item is requi
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Command to start VLC for screen recording. You can specify bitrate and other parameters.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Kommando för att starta VLC för skärminspelning. Du kan ange bithastighet och andra parametrar.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -29939,6 +33731,10 @@ For versions earlier than 7 during the installation, the following item is requi
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Audio settings</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Ljudinställningar</v8:content>
 																				</v8:item>
 																			</Title>
 																			<ToolTip>
@@ -30040,6 +33836,10 @@ For versions earlier than 7 during the installation, the following item is requi
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Make voiceovers for the video</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Skapa röstinspelningar för videon</v8:content>
+																						</v8:item>
 																					</Title>
 																					<TitleLocation>Right</TitleLocation>
 																					<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -30056,6 +33856,10 @@ For versions earlier than 7 during the installation, the following item is requi
 																								<v8:lang>en</v8:lang>
 																								<v8:content>Switches on the voicing of the video.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Aktiverar röstningen av videon.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																					<Events>
@@ -30071,6 +33875,10 @@ For versions earlier than 7 during the installation, the following item is requi
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Music</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Musik</v8:content>
 																						</v8:item>
 																					</Title>
 																					<Group>Horizontal</Group>
@@ -30184,6 +33992,12 @@ For versions earlier than 7 during the installation, the following item is requi
 If this field is filled, random mp3 file will be retrieved from this catalog as a soundtrack.
 If mp3 file duration is less than the video's, it will be repeated.</v8:content>
 																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>mp3-filkatalog.
+Om detta fält är ifyllt hämtas en slumpmässig mp3-fil från denna katalog som ljudspår.
+Om mp3-filens varaktighet är kortare än videons upprepas den.</v8:content>
+																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
 																							<Events>
@@ -30212,6 +34026,13 @@ If mp3 file duration is less than the video's, it will be repeated.</v8:content>
 If the specified value is 0, it will not affect music volume.
 If value is greater than zero (e.g., 0.06), it will affect the volume of the soundtrack.
 Recommended value is 0.1 or less.</v8:content>
+																									</v8:item>
+																									<v8:item>
+																										<v8:lang>sv</v8:lang>
+																										<v8:content>Värdeintervall är från 0 till 1.
+Om det angivna värdet är 0 påverkar det inte musikvolymen.
+Om värdet är större än noll (t.ex. 0,06) påverkar det volymen för ljudspåret.
+Rekommenderat värde är 0,1 eller mindre.</v8:content>
 																									</v8:item>
 																								</Title>
 																							</ExtendedTooltip>
@@ -30413,6 +34234,10 @@ Recommended value is 0.1 or less.</v8:content>
 																								<v8:lang>en</v8:lang>
 																								<v8:content>The path to the image used for mouse cursor appearance.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Sökvägen till bilden som används för muspekarens utseende.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																					<Events>
@@ -30527,6 +34352,12 @@ Recommended value is 0.1 or less.</v8:content>
 Watermark will be placed in the lower right corner of the video.
 The image resolution must be less than the resolution in which the video is recorded.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Png-bild som används som vattenstämpel.
+Vattenstämpeln placeras i nedre högra hörnet av videon.
+Bildupplösningen måste vara lägre än upplösningen som videon spelas in i.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																					<Events>
@@ -30559,6 +34390,14 @@ Is the specified value is 0, than there is no limit on the speeding up.
 Recommended value is 30%.
 Then in the example above the video will speed up (10 * (1-0.3)) from 10 to 7 seconds.</v8:content>
 																							</v8:item>
+																							<v8:item>
+																								<v8:lang>sv</v8:lang>
+																								<v8:content>Maximal hastighetsprocent tillgänglig för videoklipp (för ett enstaka steg).
+Videomonteringsmekanismen kan snabba upp videoklippet, till exempel om ljudspåret för videon är 5 sekunder långt och videoklippet är 10 sekunder långt.
+Om det angivna värdet är 0 finns ingen gräns för uppsnabbningen.
+Rekommenderat värde är 30%.
+Då snabbas videon i exemplet ovan upp (10 * (1-0.3)) från 10 till 7 sekunder.</v8:content>
+																							</v8:item>
 																						</Title>
 																					</ExtendedTooltip>
 																				</InputField>
@@ -30571,6 +34410,10 @@ Then in the example above the video will speed up (10 * (1-0.3)) from 10 to 7 se
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Settings</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Inställningar</v8:content>
 																						</v8:item>
 																					</Title>
 																					<VerticalStretch>false</VerticalStretch>
@@ -30588,6 +34431,10 @@ Then in the example above the video will speed up (10 * (1-0.3)) from 10 to 7 se
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Video settings additional left</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Videoinställningar extra vänster</v8:content>
 																								</v8:item>
 																							</Title>
 																							<Representation>None</Representation>
@@ -30611,6 +34458,10 @@ Then in the example above the video will speed up (10 * (1-0.3)) from 10 to 7 se
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Switches on adding video subtitles.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Aktiverar tillägg av videoundertexter.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30630,6 +34481,10 @@ Then in the example above the video will speed up (10 * (1-0.3)) from 10 to 7 se
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Switches on the mode, when each first level group of scenario steps will be converter to one step in automanual.</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Aktiverar läget när varje första nivåns grupp av scenariosteg konverteras till ett steg i automanualen.</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -30653,6 +34508,11 @@ Then in the example above the video will speed up (10 * (1-0.3)) from 10 to 7 se
 																												<v8:content>Hides service console windows used for video assembly.
 Speeds up video assembly. This mode is recommended.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Döljer servicekonsolfönster som används för videomontering.
+Snabbar upp videomonteringen. Detta läge rekommenderas.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30673,6 +34533,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Switches of video snippets scaling by time.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Växlar för videosnuttskalning efter tid.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30687,6 +34551,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Video settings extra right</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Videoinställningar extra höger</v8:content>
 																								</v8:item>
 																							</Title>
 																							<Representation>None</Representation>
@@ -30710,6 +34578,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Switches off creating of video initial slide with feature file header.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Stänger av skapandet av videons startslide med feature-filens rubrik.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30729,6 +34601,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Switches off creating of video initial slide with scenario header.</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Stänger av skapandet av videons startslide med scenariorubrik.</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -30750,6 +34626,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>Switches off creating of video final slide with video total information.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Stänger av skapandet av videons slutslide med sammanfattad videoinformation.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30764,6 +34644,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Deprecated. Move mouse to active control</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Utgått. Flytta mus till aktivt kontrollelement</v8:content>
 																										</v8:item>
 																									</Title>
 																									<TitleTextColor>style:BorderColor</TitleTextColor>
@@ -30784,6 +34668,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Deprecated. Show active form controls</v8:content>
 																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Utgått. Visa aktiva formulärkontroller</v8:content>
+																										</v8:item>
 																									</Title>
 																									<TitleTextColor>style:BorderColor</TitleTextColor>
 																									<TitleLocation>Right</TitleLocation>
@@ -30802,6 +34690,10 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Deprecated. Highlight mouse clicks</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Utgått. Markera musklick</v8:content>
 																										</v8:item>
 																									</Title>
 																									<TitleTextColor>style:BorderColor</TitleTextColor>
@@ -30822,6 +34714,11 @@ Speeds up video assembly. This mode is recommended.</v8:content>
 																												<v8:content>Switches on mouse clicks highlighting. Project utility UIToolsFor1C is used.
 SikuliX emulates mouse clicks.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Aktiverar markering av musklick. Projektverktyget UIToolsFor1C används.
+SikuliX emulerar musklick.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30836,6 +34733,10 @@ SikuliX emulates mouse clicks.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Deprecated. Emulate keyboard input</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Utgått. Emulera tangentbordsinmatning</v8:content>
 																										</v8:item>
 																									</Title>
 																									<TitleTextColor>style:BorderColor</TitleTextColor>
@@ -30858,6 +34759,12 @@ SikuliX emulates mouse clicks.</v8:content>
 Only Russian and English are available.
 Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content> Aktiverar emulering av textinmatning. Projektverktyget UIToolsFor1C används.
+Endast ryska och engelska är tillgängliga.
+Tangentbordslayout växlas genom emulering av Ctrl+Shift.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30875,6 +34782,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Group slides settings</v8:content>
 																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Grupp slide-inställningar</v8:content>
+																						</v8:item>
 																					</Title>
 																					<ToolTip>
 																						<v8:item>
@@ -30884,6 +34795,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																						<v8:item>
 																							<v8:lang>en</v8:lang>
 																							<v8:content>Group slides settings</v8:content>
+																						</v8:item>
+																						<v8:item>
+																							<v8:lang>sv</v8:lang>
+																							<v8:content>Grupp slide-inställningar</v8:content>
 																						</v8:item>
 																					</ToolTip>
 																					<Group>Vertical</Group>
@@ -30901,6 +34816,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Customize the title slide features</v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Anpassa titelslidens funktioner</v8:content>
+																								</v8:item>
 																							</Title>
 																							<ToolTip>
 																								<v8:item>
@@ -30910,6 +34829,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Group intro file settings</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Grupp intro-filinställningar</v8:content>
 																								</v8:item>
 																							</ToolTip>
 																							<Group>Vertical</Group>
@@ -30934,6 +34857,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>If the flag is set, then the standard file with the feature header will be replaced with the specified video file. The video file must be of the same resolution as the video being recorded. It must also have an audio track.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Om flaggan är satt ersätts standardfilen med feature-rubriken med den angivna videofilen. Videofilen måste ha samma upplösning som videon som spelas in. Den måste också ha ett ljudspår.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																									<Events>
@@ -30957,6 +34884,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>If the check box is selected, music will be added to the video file with the feature title</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Om kryssrutan är markerad läggs musik till i videofilen med feature-titeln</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -30970,6 +34901,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																										<v8:item>
 																											<v8:lang>en</v8:lang>
 																											<v8:content>Path to the file</v8:content>
+																										</v8:item>
+																										<v8:item>
+																											<v8:lang>sv</v8:lang>
+																											<v8:content>Sökväg till filen</v8:content>
 																										</v8:item>
 																									</Title>
 																									<TitleLocation>Top</TitleLocation>
@@ -30987,6 +34922,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>The path to the video file with the feature title, which will be added instead of the standard one.</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Sökvägen till videofilen med feature-titeln, som läggs till istället för standardfilen.</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -31006,6 +34945,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Final slide settings </v8:content>
 																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Inställningar för sista bilden </v8:content>
+																								</v8:item>
 																							</Title>
 																							<ToolTip>
 																								<v8:item>
@@ -31015,6 +34958,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																								<v8:item>
 																									<v8:lang>en</v8:lang>
 																									<v8:content>Group settings file outro</v8:content>
+																								</v8:item>
+																								<v8:item>
+																									<v8:lang>sv</v8:lang>
+																									<v8:content>Grupp inställningsfil outro</v8:content>
 																								</v8:item>
 																							</ToolTip>
 																							<Group>Vertical</Group>
@@ -31039,6 +34986,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>If the flag is set, then the standard final file will be replaced with the specified video file. The video file must be of the same resolution as the video being recorded. It must also have an audio track.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Om flaggan är satt ersätts standardslutfilen med den angivna videofilen. Videofilen måste ha samma upplösning som videon som spelas in. Den måste också ha ett ljudspår.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																									<Events>
@@ -31062,6 +35013,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>If the check box is selected, music will be added to the final video file.</v8:content>
 																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Om kryssrutan är markerad läggs musik till i den slutliga videofilen.</v8:content>
+																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
 																								</CheckBoxField>
@@ -31082,6 +35037,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																											<v8:item>
 																												<v8:lang>en</v8:lang>
 																												<v8:content>The path to the final video file that will be added instead of the standard final video file.</v8:content>
+																											</v8:item>
+																											<v8:item>
+																												<v8:lang>sv</v8:lang>
+																												<v8:content>Sökvägen till den slutliga videofilen som läggs till istället för den vanliga slutvideofilen.</v8:content>
 																											</v8:item>
 																										</Title>
 																									</ExtendedTooltip>
@@ -31111,6 +35070,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>SikuliX server (deprecated)</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>SikuliX-server (utgått)</v8:content>
+														</v8:item>
 													</Title>
 													<ToolTip>
 														<v8:item>
@@ -31120,6 +35083,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Tooltip</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Verktygstips</v8:content>
 														</v8:item>
 													</ToolTip>
 													<Group>Vertical</Group>
@@ -31139,6 +35106,10 @@ Keyboard layout shwitches by pressing Ctrl+Shift emulation.</v8:content>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Use SikuliX Server</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Använd SikuliX-server</v8:content>
 																</v8:item>
 															</ToolTip>
 															<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
@@ -31166,6 +35137,16 @@ SikuliX Server - это специальная программная оптим
 &lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Installation and configuration of SikuliX and SikuliX Server is described in help section 20.1&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
 
 &lt;link #&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Open Help&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
+																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;SikuliX är en Java-applikation som låter dig styra musrörelser och klick på skärmen, samt emulera tangenttryckningar på tangentbordet.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;SikuliX Server är en speciell programvaruoptimering för att arbeta med SikuliX. Om alternativet är aktiverat bygger VA ett stort skript från många SikuliX-skript, som kan köras en gång och snabbt utföra nödvändiga kommandon som tidigare var tvungna att köras ett i taget. Detta gör att du avsevärt sparar tid för att köra ett SikuliX-skript, eftersom ingen tid slösas på att starta SikuliX och ladda ur det från minnet.&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+
+&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Installation och konfiguration av SikuliX och SikuliX Server beskrivs i hjälpavsnitt 20.1&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;
+
+&lt;link #&gt;&lt;font Almarai&gt;&lt;fontsize 8&gt;&lt;color #333333&gt;&lt;bgcolor #FFFFFF&gt;Öppna hjälp&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;&lt;/&gt;</v8:content>
 																	</v8:item>
 																</Title>
 																<Events>
@@ -31197,6 +35178,12 @@ SikuliX Server - это специальная программная оптим
 SikuliX is used for picture search and mouse movement. Picture will be generated by the text from the form element.
 To disable mouse movement at a specific step, you should use the #[DoNotMoveMouse] directive.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Om kryssrutan är aktiverad utförs sökning av formulärelement eller kontroll vid stegkörning. Muspekaren flyttas till det upptäckta elementet. 
+SikuliX används för bildsökning och musrörelse. Bilden genereras från texten i formulärelementet.
+För att inaktivera musrörelse vid ett specifikt steg, använd direktivet #[DoNotMoveMouse].</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<Events>
@@ -31213,6 +35200,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Sikuli x server details</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>SikuliX-serverdetaljer</v8:content>
+																</v8:item>
 															</Title>
 															<ToolTip>
 																<v8:item>
@@ -31222,6 +35213,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group sikuli x server details</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp SikuliX-serverdetaljer</v8:content>
 																</v8:item>
 															</ToolTip>
 															<Group>Vertical</Group>
@@ -31242,6 +35237,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Install service programs</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Installera serviceprogram</v8:content>
+																		</v8:item>
 																	</Title>
 																	<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																	<ExtendedTooltip name="УстановитьСервисныеУтилитыРасширеннаяПодсказка" id="2147"/>
@@ -31256,6 +35255,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																			<v8:lang>en</v8:lang>
 																			<v8:content>SikuliX scripts directory path</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Sökväg till SikuliX-skriptkatalog</v8:content>
+																		</v8:item>
 																	</Title>
 																	<ToolTip>
 																		<v8:item>
@@ -31265,6 +35268,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>SikuliX scripts directory path</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Sökväg till SikuliX-skriptkatalog</v8:content>
 																		</v8:item>
 																	</ToolTip>
 																	<Group>Horizontal</Group>
@@ -31284,6 +35291,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																					<v8:lang>en</v8:lang>
 																					<v8:content>SikuliX scripts directory</v8:content>
 																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>SikuliX-skriptkatalog</v8:content>
+																				</v8:item>
 																			</ToolTip>
 																			<ToolTipRepresentation>ShowBottom</ToolTipRepresentation>
 																			<ChoiceButton>true</ChoiceButton>
@@ -31298,6 +35309,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																					<v8:item>
 																						<v8:lang>ru</v8:lang>
 																						<v8:content>Каталог скриптов. Можно указывать несколько каталогов, разделенных через ";".</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Skriptkatalog. Flera kataloger kan användas, separerade med ";".</v8:content>
 																					</v8:item>
 																				</Title>
 																			</ExtendedTooltip>
@@ -31318,6 +35333,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																				<v8:item>
 																					<v8:lang>en</v8:lang>
 																					<v8:content>Default directory</v8:content>
+																				</v8:item>
+																				<v8:item>
+																					<v8:lang>sv</v8:lang>
+																					<v8:content>Standardkatalog</v8:content>
 																				</v8:item>
 																			</Title>
 																			<ExtendedTooltip name="КаталогиСкриптовSikuliXПоУмолчаниюРасширеннаяПодсказка" id="2143"/>
@@ -31348,6 +35367,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																		<v8:lang>en</v8:lang>
 																		<v8:content>The directory in which pictures will be programmatically created to search for them on the screen.</v8:content>
 																	</v8:item>
+																	<v8:item>
+																		<v8:lang>sv</v8:lang>
+																		<v8:content>Katalogen där bilder skapas programmatiskt för att söka efter dem på skärmen.</v8:content>
+																	</v8:item>
 																</Title>
 															</ExtendedTooltip>
 															<Events>
@@ -31363,6 +35386,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Group color profiles</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Grupp färgprofiler</v8:content>
 																</v8:item>
 															</Title>
 															<Group>Vertical</Group>
@@ -31387,6 +35414,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Profiles</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Profiler</v8:content>
 																		</v8:item>
 																	</Title>
 																	<RowFilter xsi:nil="true"/>
@@ -31474,6 +35505,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 													<v8:lang>en</v8:lang>
 													<v8:content>Vanessa Editor</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Vanessa-redigerare</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаНастройкиVanessaEditorРасширеннаяПодсказка" id="2412"/>
 											<ChildItems>
@@ -31485,6 +35520,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 														</v8:item>
 														<v8:item>
 															<v8:lang>en</v8:lang>
+															<v8:content>Version</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
 															<v8:content>Version</v8:content>
 														</v8:item>
 													</Title>
@@ -31501,6 +35540,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 															<v8:lang>en</v8:lang>
 															<v8:content>Vanessa editor setup page first line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vanessa-redigerarinställningssida första raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>NormalSeparation</Representation>
@@ -31516,6 +35559,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Vanessa editor setup page first line left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida första raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -31541,6 +35588,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Включает возможность использовать данные текущей формы клиента тестирования, таких как имена полей, заголовков окон и так далее при подборе шагов.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar möjligheten att använda data från det aktuella testklientformuläret, såsom fältnamn, fönstertitlar och så vidare, vid tillägg av steg.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31558,6 +35609,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Vanessa editor setup page first line right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida första raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -31581,6 +35636,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Включает отображение строк подсценариев в редакторе.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar visningen av underskriptrader i redigeraren.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31601,6 +35660,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 															<v8:lang>en</v8:lang>
 															<v8:content>vanessa editor setup page second line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vanessa-redigerarinställningssida andra raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>NormalSeparation</Representation>
@@ -31616,6 +35679,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Vanessa editor setup page second line left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida andra raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -31641,6 +35708,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Управляет отображением миниатюры кода.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Styr visningen av kodminiatyren.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31658,6 +35729,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Vanessa editor setup page second line left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida andra raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -31681,6 +35756,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Опция определяет надо ли заменять в редакторе символы табуляции на пробелы.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Alternativet bestämmer om tabbar ska ersättas med mellanslag i redigeraren.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31701,6 +35780,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 															<v8:lang>en</v8:lang>
 															<v8:content>vanessa editor setup page third line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vanessa-redigerarinställningssida tredje raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>NormalSeparation</Representation>
@@ -31716,6 +35799,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page third row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida tredje raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -31741,6 +35828,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Если опция установлена, то закладки будут отображаться сверху. Это нужно, чтобы предоставить редактору сценария больше места для отображения сценария.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om alternativet är satt visas bokmärken längst upp. Detta ger skriptredigeraren mer utrymme att visa skriptet.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31758,6 +35849,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page third row right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida tredje raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -31781,6 +35876,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Опция для включения/отключения проверки синтаксиса в редакторе сценариев</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Alternativ för att aktivera/inaktivera syntaxkontroll i skriptredigeraren</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31801,6 +35900,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 															<v8:lang>en</v8:lang>
 															<v8:content>vanessa editor setup page fourth line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vanessa-redigerarinställningssida fjärde raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>None</Representation>
@@ -31816,6 +35919,10 @@ To disable mouse movement at a specific step, you should use the #[DoNotMoveMous
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page fourth row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida fjärde raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -31843,6 +35950,11 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																				<v8:content>Управляет режимом отображения различий при сравнении файлов в редакторе.
 Если опция включена - то отображается два столбца, иначе различия показываются в тексте файла.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Styr hur skillnader visas vid jämförelse av filer i redigeraren.
+Om alternativet är aktiverat visas två kolumner, annars visas skillnaderna i filens text.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31860,6 +35972,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page fourth row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida fjärde raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -31883,6 +35999,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Включает отображение начальной страницы в редакторе при запуске Vanessa Automation.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar visning av startsidan i redigeraren när Vanessa Automation startar.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -31900,6 +36020,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 															<v8:lang>en</v8:lang>
 															<v8:content>vanessa editor setup page sixth line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vanessa-redigerarinställningssida sjätte raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>NormalSeparation</Representation>
@@ -31915,6 +36039,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page sixth row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida sjätte raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -31940,6 +36068,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Включает отображение в редакторе данных по значениям переменных (inline debug). Значения переменных обновляются после того как строка шага выполнена.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Aktiverar visning av data efter variabelvärden i redigeraren (inline-felsökning). Variabelvärden uppdateras efter att stegraden har körts.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -31957,6 +36089,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page sixth row right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida sjätte raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -31981,6 +36117,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Если при работе в редакторе была нажата клавиша Esc, то это вызовет событие закрытия формы Vanessa Automation.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om Esc-tangenten trycks ned medan du arbetar i redigeraren utlöser detta stängningshändelsen för Vanessa Automation-formuläret.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -31998,6 +36138,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 															<v8:lang>en</v8:lang>
 															<v8:content>vanessa editor setup page fifth line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vanessa-redigerarinställningssida femte raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>None</Representation>
@@ -32013,6 +36157,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page fifth row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida femte raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -32042,6 +36190,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Selection</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Urval</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:decimal">0</Value>
 																			</xr:Value>
@@ -32058,6 +36210,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
 																						<v8:content>None</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Ingen</v8:content>
 																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:decimal">1</Value>
@@ -32076,6 +36232,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Boundary</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Gräns</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:decimal">2</Value>
 																			</xr:Value>
@@ -32093,6 +36253,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																						<v8:lang>en</v8:lang>
 																						<v8:content>All</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Alla</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:decimal">3</Value>
 																			</xr:Value>
@@ -32109,6 +36273,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																			<v8:item>
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Изменяет режим отображения табуляции и пробелов</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Ändrar visningsläget för tabbar och mellanslag</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -32128,6 +36296,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor setup page fifth row right column</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida femte raden höger kolumn</v8:content>
+																</v8:item>
 															</Title>
 															<Representation>None</Representation>
 															<ShowTitle>false</ShowTitle>
@@ -32143,6 +36315,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																		<v8:item>
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Editor theme</v8:content>
+																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Redigerartema</v8:content>
 																		</v8:item>
 																	</Title>
 																	<TitleLocation>Top</TitleLocation>
@@ -32162,6 +36338,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																						<v8:lang>en</v8:lang>
 																						<v8:content>1C:Enterprise</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>1C:Enterprise</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:string">1c</Value>
 																			</xr:Value>
@@ -32177,6 +36357,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																					</v8:item>
 																					<v8:item>
 																						<v8:lang>en</v8:lang>
+																						<v8:content>Visual Studio</v8:content>
+																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
 																						<v8:content>Visual Studio</v8:content>
 																					</v8:item>
 																				</Presentation>
@@ -32196,6 +36380,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																						<v8:lang>en</v8:lang>
 																						<v8:content>Visual Studio Dark</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Visual Studio Dark</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:string">vs-dark</Value>
 																			</xr:Value>
@@ -32213,6 +36401,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																						<v8:lang>en</v8:lang>
 																						<v8:content>High Contrast Dark</v8:content>
 																					</v8:item>
+																					<v8:item>
+																						<v8:lang>sv</v8:lang>
+																						<v8:content>Hög kontrast mörk</v8:content>
+																					</v8:item>
 																				</Presentation>
 																				<Value xsi:type="xs:string">hc-black</Value>
 																			</xr:Value>
@@ -32229,6 +36421,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																			<v8:item>
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Позволяет сменить тему редактора.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Låter dig ändra redigerarens tema.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -32250,6 +36446,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 															<v8:lang>en</v8:lang>
 															<v8:content>Vanessa editor setup page seventh line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Vanessa-redigerarinställningssida sjunde raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>None</Representation>
@@ -32265,6 +36465,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor settings page seventh line left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida sjunde raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -32289,6 +36493,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>vanessa editor settings page seventh line right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Vanessa-redigerarinställningssida sjunde raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -32316,6 +36524,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 													<v8:lang>en</v8:lang>
 													<v8:content>Training</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Utbildning</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаОбучениеРасширеннаяПодсказка" id="3158"/>
 											<ChildItems>
@@ -32328,6 +36540,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Page training first line</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sida utbildning första raden</v8:content>
 														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
@@ -32344,6 +36560,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Training page first row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Utbildningssida första raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -32369,6 +36589,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Определяет, нужно ли создавать mp3 файлы озвучки для интерактивной справки если они не были найдены в кэш.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Bestämmer om mp3-ljudfiler för onlinehjälp ska skapas om de inte hittades i cachen.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -32383,6 +36607,10 @@ If the option is enabled, then two columns are displayed, otherwise the differen
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Training page first row right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Utbildningssida första raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -32412,6 +36640,13 @@ For this option to work, you must enable the use of the VanessaExt component.</v
 2. При нажатии сочетания клавиш alt+H будет выполнен поиск уроков интерактивной справки, в которых участвует данный элемент формы.
 Для работы опции необходимо включить использование компоненты VanessaExt.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om alternativet är aktiverat blir det möjligt att:
+1. Flytta muspekaren över det önskade formulärelementet
+2. Genom att trycka på tangentbordskombinationen alt+H söker man efter onlinehjälplektioner som inkluderar detta formulärelement.
+För att detta alternativ ska fungera måste du aktivera användningen av VanessaExt-komponenten.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																	<Events>
@@ -32432,6 +36667,10 @@ For this option to work, you must enable the use of the VanessaExt component.</v
 															<v8:lang>en</v8:lang>
 															<v8:content>Page training second line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Sida utbildning andra raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>None</Representation>
@@ -32447,6 +36686,10 @@ For this option to work, you must enable the use of the VanessaExt component.</v
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page training second row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida utbildning andra raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -32472,6 +36715,10 @@ For this option to work, you must enable the use of the VanessaExt component.</v
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Если опция включена, то после успешного выполнения урока интерактивной справки вкладка редактора, содержащая сценарий интерактивной справки, будет закрыта.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om detta alternativ är aktiverat stängs redigerarens flik som innehåller det interaktiva hjälpskriptet efter att den interaktiva hjälplektionen har slutförts framgångsrikt.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</CheckBoxField>
@@ -32486,6 +36733,10 @@ For this option to work, you must enable the use of the VanessaExt component.</v
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Page training second row right column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Sida utbildning andra raden höger kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -32510,6 +36761,11 @@ The first launch is determined by checking if the user's settings were previousl
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Если опция включена, то при первом запуске Vanessa Automation будет показан помощник при первом запуске. Только под Windows.
 Первый запуск определяется через проверку, сохранялись ли раньше настройки пользователя в этой базе.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Om detta alternativ är aktiverat visas vid första starten av Vanessa Automation hjälpen för första gången. Bara under Windows.
+Första starten bestäms genom att kontrollera om användarens inställningar tidigare sparades i denna databas.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -32537,6 +36793,11 @@ If the voice acting file is not found in the directory, the process of generatin
 																<v8:content>Каталог,  в котором будет производится поиск файлов озвучки интерактивной справки в первую очередь.
 Если файл озвучки в каталоге будет не найден, то будет запущен процесс генерации озвучки диктором.</v8:content>
 															</v8:item>
+															<v8:item>
+																<v8:lang>sv</v8:lang>
+																<v8:content>Katalogen där röstfiler för onlinehjälpen söks först.
+Om röstfilen inte hittas i katalogen startas processen för att generera röstning av speakern.</v8:content>
+															</v8:item>
 														</Title>
 													</ExtendedTooltip>
 													<Events>
@@ -32558,6 +36819,10 @@ If the voice acting file is not found in the directory, the process of generatin
 															<v8:lang>en</v8:lang>
 															<v8:content>Documentation options</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Dokumentationsalternativ</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Behavior>Collapsible</Behavior>
@@ -32576,6 +36841,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Start lesson</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Starta lektion</v8:content>
+																</v8:item>
 															</Title>
 															<TitleLocation>Right</TitleLocation>
 															<CheckBoxType>Auto</CheckBoxType>
@@ -32592,6 +36861,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Video lessons</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Videolektioner</v8:content>
 																</v8:item>
 															</Title>
 															<TitleLocation>Right</TitleLocation>
@@ -32610,6 +36883,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																	<v8:lang>en</v8:lang>
 																	<v8:content>PDF</v8:content>
 																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>PDF</v8:content>
+																</v8:item>
 															</Title>
 															<TitleLocation>Right</TitleLocation>
 															<CheckBoxType>Auto</CheckBoxType>
@@ -32625,6 +36902,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																</v8:item>
 																<v8:item>
 																	<v8:lang>en</v8:lang>
+																	<v8:content>MD</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
 																	<v8:content>MD</v8:content>
 																</v8:item>
 															</Title>
@@ -32647,6 +36928,10 @@ If the voice acting file is not found in the directory, the process of generatin
 													<v8:lang>en</v8:lang>
 													<v8:content>Other</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Övrigt</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаНастройкиПрочееРасширеннаяПодсказка" id="1659"/>
 											<ChildItems>
@@ -32659,6 +36944,10 @@ If the voice acting file is not found in the directory, the process of generatin
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Setting page other first line</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Inställningssida övrigt första raden</v8:content>
 														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
@@ -32675,6 +36964,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Setting page other first row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Inställningssida övrigt första raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -32695,6 +36988,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																			<v8:lang>en</v8:lang>
 																			<v8:content>Calculate PID</v8:content>
 																		</v8:item>
+																		<v8:item>
+																			<v8:lang>sv</v8:lang>
+																			<v8:content>Beräkna PID</v8:content>
+																		</v8:item>
 																	</Title>
 																	<ToolTipRepresentation>Balloon</ToolTipRepresentation>
 																	<ExtendedTooltip name="ВычислитьPIDЭтогоСеанса1РасширеннаяПодсказка" id="1663">
@@ -32707,6 +37004,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																			<v8:item>
 																				<v8:lang>en</v8:lang>
 																				<v8:content>Calculates PID of the current 1C session where Vanessa Automation is started.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Beräknar PID för den aktuella 1C-sessionen där Vanessa Automation har startats.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -32722,6 +37023,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Setting page other first row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Inställningssida övrigt första raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Representation>None</Representation>
@@ -32833,6 +37138,10 @@ If the voice acting file is not found in the directory, the process of generatin
 															<v8:lang>en</v8:lang>
 															<v8:content>Setting page other second line</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Inställningssida övrigt andra raden</v8:content>
+														</v8:item>
 													</Title>
 													<Group>AlwaysHorizontal</Group>
 													<Representation>None</Representation>
@@ -32848,6 +37157,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																<v8:item>
 																	<v8:lang>en</v8:lang>
 																	<v8:content>Setting page other second row left column</v8:content>
+																</v8:item>
+																<v8:item>
+																	<v8:lang>sv</v8:lang>
+																	<v8:content>Inställningssida övrigt andra raden vänster kolumn</v8:content>
 																</v8:item>
 															</Title>
 															<Width>50</Width>
@@ -32872,6 +37185,10 @@ If the voice acting file is not found in the directory, the process of generatin
 																				<v8:lang>ru</v8:lang>
 																				<v8:content>Позволяет получить строку запуска тестов из командной строки для данной базы.</v8:content>
 																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Låter dig hämta teststartssträngen från kommandoraden för den angivna databasen.</v8:content>
+																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
 																</Button>
@@ -32892,6 +37209,12 @@ Click on the hyperlink for more details.</v8:content>
 																				<v8:content>Позволяет получить строку запуска тестов из командной строки для данной базы. При этом Vanessa Automation запускается с помощью OneScript.
 При этом будет работать вывод сообщений в консоль. Это более быстрый способ, т.к. не нужно читать лог из текстового файла.
 Нажми на гиперссылку, чтобы узнать подробности.</v8:content>
+																			</v8:item>
+																			<v8:item>
+																				<v8:lang>sv</v8:lang>
+																				<v8:content>Låter dig hämta teststartkommandot från kommandoraden för den angivna databasen. Detta startar Vanessa Automation med OneScript.
+I detta fall fungerar utmatningen av meddelanden till konsolen. Detta är ett snabbare sätt eftersom det inte behövs att läsa loggen från en textfil.
+Klicka på hyperlänken för mer detaljer.</v8:content>
 																			</v8:item>
 																		</Title>
 																	</ExtendedTooltip>
@@ -33006,6 +37329,10 @@ Click on the hyperlink for more details.</v8:content>
 											<v8:lang>en</v8:lang>
 											<v8:content>Page service</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Sida service</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="ГруппаСтраницыСлужебныеРасширеннаяПодсказка" id="1636"/>
 									<ChildItems>
@@ -33018,6 +37345,10 @@ Click on the hyperlink for more details.</v8:content>
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Service main</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Service huvud</v8:content>
 												</v8:item>
 											</Title>
 											<ExtendedTooltip name="СтраницаСлужебноеОсновноеРасширеннаяПодсказка" id="1638"/>
@@ -33253,6 +37584,10 @@ Click on the hyperlink for more details.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Runner ID</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Körnings-ID</v8:content>
+														</v8:item>
 													</Title>
 													<ContextMenu name="ИДПотокаКонтекстноеМеню" id="1687"/>
 													<ExtendedTooltip name="ИДПотокаРасширеннаяПодсказка" id="1688"/>
@@ -33303,6 +37638,10 @@ Click on the hyperlink for more details.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Self-test mode</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Självtestläge</v8:content>
+														</v8:item>
 													</Title>
 													<CheckBoxType>Auto</CheckBoxType>
 													<ContextMenu name="РежимСамотестированияКонтекстноеМеню" id="1668"/>
@@ -33323,6 +37662,10 @@ Click on the hyperlink for more details.</v8:content>
 													<v8:lang>en</v8:lang>
 													<v8:content>Execute code</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Kör kod</v8:content>
+												</v8:item>
 											</Title>
 											<ExtendedTooltip name="ГруппаСлужебноеВыполнитьКодРасширеннаяПодсказка" id="1640"/>
 											<ChildItems>
@@ -33342,6 +37685,10 @@ Click on the hyperlink for more details.</v8:content>
 															<v8:lang>en</v8:lang>
 															<v8:content>Arbitrary code</v8:content>
 														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Godtycklig kod</v8:content>
+														</v8:item>
 													</Title>
 													<AutoMaxWidth>false</AutoMaxWidth>
 													<MultiLine>true</MultiLine>
@@ -33359,6 +37706,10 @@ Click on the hyperlink for more details.</v8:content>
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Table step definition</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Tabellstegdefinition</v8:content>
 												</v8:item>
 											</Title>
 											<ExtendedTooltip name="ТаблицаStepDefinitionРасширеннаяПодсказка" id="1650"/>
@@ -33378,6 +37729,10 @@ Click on the hyperlink for more details.</v8:content>
 														<v8:item>
 															<v8:lang>en</v8:lang>
 															<v8:content>Table of known step definitions</v8:content>
+														</v8:item>
+														<v8:item>
+															<v8:lang>sv</v8:lang>
+															<v8:content>Tabell med kända stegdefinitioner</v8:content>
 														</v8:item>
 													</Title>
 													<RowFilter xsi:nil="true"/>
@@ -33512,6 +37867,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Status</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Status</v8:content>
+						</v8:item>
 					</Title>
 					<TitleLocation>None</TitleLocation>
 					<ContextMenu name="СтрокаСтатусаКонтекстноеМеню" id="1718"/>
@@ -33528,6 +37887,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>View variables</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Visa variabler</v8:content>
+						</v8:item>
 					</Title>
 					<Group>Vertical</Group>
 					<Representation>None</Representation>
@@ -33543,6 +37906,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Group of buttons to view variables</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Grupp av knappar för att visa variabler</v8:content>
 								</v8:item>
 							</Title>
 							<Group>AlwaysHorizontal</Group>
@@ -33568,6 +37935,10 @@ Click on the hyperlink for more details.</v8:content>
 											<v8:lang>en</v8:lang>
 											<v8:content>Refresh variables boar</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Uppdatera variabeltavla</v8:content>
+										</v8:item>
 									</Title>
 									<ExtendedTooltip name="ТаблоПеременныхОбновитьТаблоПеременныхРасширеннаяПодсказка" id="1944"/>
 								</Button>
@@ -33592,6 +37963,10 @@ Click on the hyperlink for more details.</v8:content>
 											<v8:lang>en</v8:lang>
 											<v8:content>Command panel variables from file</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Kommandopanel variabler från fil</v8:content>
+										</v8:item>
 									</Title>
 									<Width>9</Width>
 									<ExtendedTooltip name="КоманднаяПанельСохранитьЗагрузитьПеременныеИзФайлаРасширеннаяПодсказка" id="4131"/>
@@ -33606,6 +37981,10 @@ Click on the hyperlink for more details.</v8:content>
 													<v8:lang>en</v8:lang>
 													<v8:content>Save/Load Variables</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Spara/Ladda variabler</v8:content>
+												</v8:item>
 											</Title>
 											<ToolTip>
 												<v8:item>
@@ -33615,6 +37994,10 @@ Click on the hyperlink for more details.</v8:content>
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Save/Load Variables</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Spara/Ladda variabler</v8:content>
 												</v8:item>
 											</ToolTip>
 											<ExtendedTooltip name="ГруппаКнопокСохранитьЗагрузитьПеременныеРасширеннаяПодсказка" id="4133"/>
@@ -33643,6 +38026,10 @@ Click on the hyperlink for more details.</v8:content>
 											<v8:lang>en</v8:lang>
 											<v8:content>The command panel of the rollback system</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Kommandopanelen för återställningssystemet</v8:content>
+										</v8:item>
 									</Title>
 									<ToolTip>
 										<v8:item>
@@ -33652,6 +38039,10 @@ Click on the hyperlink for more details.</v8:content>
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>The command panel of the rollback system</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Kommandopanelen för återställningssystemet</v8:content>
 										</v8:item>
 									</ToolTip>
 									<Width>10</Width>
@@ -33667,6 +38058,10 @@ Click on the hyperlink for more details.</v8:content>
 													<v8:lang>en</v8:lang>
 													<v8:content>Rollback System Buttons</v8:content>
 												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Knappar för återställningssystem</v8:content>
+												</v8:item>
 											</Title>
 											<ToolTip>
 												<v8:item>
@@ -33676,6 +38071,10 @@ Click on the hyperlink for more details.</v8:content>
 												<v8:item>
 													<v8:lang>en</v8:lang>
 													<v8:content>Rollback System Buttons</v8:content>
+												</v8:item>
+												<v8:item>
+													<v8:lang>sv</v8:lang>
+													<v8:content>Knappar för återställningssystem</v8:content>
 												</v8:item>
 											</ToolTip>
 											<ExtendedTooltip name="ГруппаКнопокСистемыОткатаРасширеннаяПодсказка" id="4083"/>
@@ -33725,6 +38124,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Variables board</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Variabeltavla</v8:content>
 								</v8:item>
 							</Title>
 							<ContextMenu name="ТаблоПеременныхКонтекстноеМеню" id="1916"/>
@@ -33815,6 +38218,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Information</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Information</v8:content>
+						</v8:item>
 					</Title>
 					<HorizontalStretch>true</HorizontalStretch>
 					<Group>Horizontal</Group>
@@ -33833,6 +38240,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:item>
 									<v8:lang>en</v8:lang>
 									<v8:content>Current feature file</v8:content>
+								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Aktuell feature-fil</v8:content>
 								</v8:item>
 							</Title>
 							<Width>50</Width>
@@ -33853,6 +38264,10 @@ Click on the hyperlink for more details.</v8:content>
 									<v8:lang>en</v8:lang>
 									<v8:content>Statistics</v8:content>
 								</v8:item>
+								<v8:item>
+									<v8:lang>sv</v8:lang>
+									<v8:content>Statistik</v8:content>
+								</v8:item>
 							</Title>
 							<Group>Horizontal</Group>
 							<Representation>None</Representation>
@@ -33869,6 +38284,10 @@ Click on the hyperlink for more details.</v8:content>
 											<v8:lang>en</v8:lang>
 											<v8:content>Statistics</v8:content>
 										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Statistik</v8:content>
+										</v8:item>
 									</Title>
 									<HorizontalAlign>Right</HorizontalAlign>
 									<ContextMenu name="СтатистикаКонтекстноеМеню" id="1599"/>
@@ -33883,6 +38302,10 @@ Click on the hyperlink for more details.</v8:content>
 										<v8:item>
 											<v8:lang>en</v8:lang>
 											<v8:content>Service flags</v8:content>
+										</v8:item>
+										<v8:item>
+											<v8:lang>sv</v8:lang>
+											<v8:content>Serviceflaggor</v8:content>
 										</v8:item>
 									</Title>
 									<Group>Horizontal</Group>
@@ -34030,6 +38453,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Full path</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Fullständig sökväg</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:string</v8:Type>
@@ -34144,6 +38571,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Snippet address</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Kodavsnittsadress</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:string</v8:Type>
@@ -34167,6 +38598,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>vi</v8:lang>
 								<v8:content>Dòng thủ tục thực tế</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Faktisk procedursträng</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:string</v8:Type>
@@ -34186,6 +38621,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Named parameters</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Namngivna parametrar</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>v8:ValueListType</v8:Type>
@@ -34200,6 +38639,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Parameter values</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Parametervärden</v8:content>
 							</v8:item>
 						</Title>
 						<Type>
@@ -34216,6 +38659,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>This is a foreign snippet</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Detta är ett externt kodavsnitt</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:boolean</v8:Type>
@@ -34230,6 +38677,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Picture type</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Bildtyp</v8:content>
 							</v8:item>
 						</Title>
 						<Type>
@@ -34250,6 +38701,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>RowID</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>RadID</v8:content>
 							</v8:item>
 						</Title>
 						<Type>
@@ -34366,6 +38821,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Feature has its EPF</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Feature har sin EPF</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:boolean</v8:Type>
@@ -34380,6 +38839,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Step with parameters in the table</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Steg med parametrar i tabellen</v8:content>
 							</v8:item>
 						</Title>
 						<Type>
@@ -34396,6 +38859,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Step parameters line as a table</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Stegparametrar rad som tabell</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:boolean</v8:Type>
@@ -34410,6 +38877,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Table parameters</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Tabellparametrar</v8:content>
 							</v8:item>
 						</Title>
 						<Type/>
@@ -34433,6 +38904,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Line number in feature</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Radnummer i feature</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:decimal</v8:Type>
@@ -34452,6 +38927,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Line number in feature</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Radnummer i feature</v8:content>
 							</v8:item>
 						</Title>
 						<Type>
@@ -34563,6 +39042,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Addl type</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Extra typ</v8:content>
+							</v8:item>
 						</Title>
 						<Type>
 							<v8:Type>xs:string</v8:Type>
@@ -34581,6 +39064,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:item>
 								<v8:lang>en</v8:lang>
 								<v8:content>Error text</v8:content>
+							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Feltext</v8:content>
 							</v8:item>
 						</Title>
 						<Type>
@@ -34601,6 +39088,10 @@ Click on the hyperlink for more details.</v8:content>
 								<v8:lang>en</v8:lang>
 								<v8:content>Arbitrary values</v8:content>
 							</v8:item>
+							<v8:item>
+								<v8:lang>sv</v8:lang>
+								<v8:content>Godtyckliga värden</v8:content>
+							</v8:item>
 						</Title>
 						<Type/>
 					</Column>
@@ -34616,6 +39107,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Table of known step definitions</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Tabell med kända stegdefinitioner</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -34731,6 +39226,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>ro</v8:lang>
 							<v8:content>Id</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>ID</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -34753,6 +39252,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>vi</v8:lang>
 							<v8:content>Dòng thủ tục thực tế</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Faktisk procedursträng</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -34777,6 +39280,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>ro</v8:lang>
 							<v8:content>Parametri</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Inställningar</v8:content>
+						</v8:item>
 					</Title>
 					<Type/>
 				</Column>
@@ -34789,6 +39296,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Search string</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Söksträng</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -34808,6 +39319,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Test view</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Testvy</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -34832,6 +39347,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>ro</v8:lang>
 							<v8:content>Tranzacția</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Transaktion</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -34854,6 +39373,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>ro</v8:lang>
 							<v8:content>Descriere pas</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegbeskrivning</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -34878,6 +39401,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>ro</v8:lang>
 							<v8:content>Tipul pas</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegtyp</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -34897,6 +39424,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>File version</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Filversion</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:dateTime</v8:Type>
@@ -34915,6 +39446,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>The string was processed</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Strängen bearbetades</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -34929,6 +39464,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Step type</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Stegtyp</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -34958,6 +39497,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Step from a configuration or extension form</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Steg från ett konfigurations- eller tilläggsformulär</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -34977,6 +39520,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>TestClients data</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>TestClients-data</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -35379,6 +39926,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Client type</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Klienttyp</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -35588,6 +40139,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>This client</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Denna klient</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -35602,6 +40157,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Window descriptor</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Fönsterdeskriptor</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -35623,6 +40182,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>PID</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>PID</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:decimal</v8:Type>
@@ -35642,6 +40205,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
 							<v8:content>Имя базы в мобильном приложении</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>IB-namn i mobilapp</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -35855,6 +40422,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Atribute arbitrary code</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Attribut godtycklig kod</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -36006,6 +40577,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Read layout start page</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Läs layout startsida</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -36025,6 +40600,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Read layout start number</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Läs layout startnummer</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -36046,6 +40625,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Read layout page number</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Läs layout sidnummer</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -36066,6 +40649,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Read layout number number</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Läs layout nummer nummer</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:decimal</v8:Type>
@@ -36085,6 +40672,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Status line</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Statusrad</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -36114,6 +40705,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Ask for confirmation before form closing</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fråga om bekräftelse innan formuläret stängs</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -36132,6 +40727,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Variables board</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Variabeltavla</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -36243,6 +40842,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Value</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Värde</v8:content>
+						</v8:item>
 					</Title>
 					<Type/>
 				</Column>
@@ -36351,6 +40954,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Data source</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Datakälla</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -36369,6 +40976,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Internal line</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Intern rad</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36392,6 +41003,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Allure labels data</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Allure-etikettdata</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -36406,6 +41021,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Regular expression</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Reguljärt uttryck</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36426,6 +41045,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Tag name</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Taggnamn</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -36444,6 +41067,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Value</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Värde</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36464,6 +41091,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Pattern</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Mönster</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -36480,6 +41111,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Voice test text</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rösttest text</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -36500,6 +41135,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Search profiles</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sökprofiler</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTable</v8:Type>
@@ -36514,6 +41153,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Font</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Teckensnitt</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36534,6 +41177,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Background color</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bakgrundsfärg</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -36553,6 +41200,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Font color</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Teckenfärg</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -36571,6 +41222,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Size</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Storlek</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36689,6 +41344,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Vanessa editor URL</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Vanessa-redigerare URL</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -36719,6 +41378,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Name</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Namn</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -36737,6 +41400,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Full path</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Fullständig sökväg</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36757,6 +41424,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>This is folder</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Detta är en mapp</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:boolean</v8:Type>
@@ -36771,6 +41442,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>File size</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Filstorlek</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36792,6 +41467,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Picture</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bild</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>v8ui:Picture</v8:Type>
@@ -36806,6 +41485,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Number of files</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Antal filer</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36828,6 +41511,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Feature folder</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Feature-mapp</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -36862,6 +41549,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Git folder</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Git-mapp</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -36881,6 +41572,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Git tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Git-träd</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>v8:ValueTree</v8:Type>
@@ -36895,6 +41590,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>File</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Fil</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36914,6 +41613,10 @@ Click on the hyperlink for more details.</v8:content>
 						<v8:item>
 							<v8:lang>en</v8:lang>
 							<v8:content>Picture type</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Bildtyp</v8:content>
 						</v8:item>
 					</Title>
 					<Type>
@@ -36935,6 +41638,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>Type</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Typ</v8:content>
+						</v8:item>
 					</Title>
 					<Type>
 						<v8:Type>xs:string</v8:Type>
@@ -36952,6 +41659,10 @@ Click on the hyperlink for more details.</v8:content>
 						</v8:item>
 						<v8:item>
 							<v8:lang>en</v8:lang>
+							<v8:content>Status</v8:content>
+						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
 							<v8:content>Status</v8:content>
 						</v8:item>
 					</Title>
@@ -36973,6 +41684,10 @@ Click on the hyperlink for more details.</v8:content>
 							<v8:lang>en</v8:lang>
 							<v8:content>File data</v8:content>
 						</v8:item>
+						<v8:item>
+							<v8:lang>sv</v8:lang>
+							<v8:content>Fildata</v8:content>
+						</v8:item>
 					</Title>
 					<Type/>
 				</Column>
@@ -36987,6 +41702,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Message text</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Meddelandetext</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -37006,6 +41725,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Settings</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Inställningar</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -37054,6 +41777,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Template VanessaEditor</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Mall VanessaEditor</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -37072,6 +41799,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Verification step</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Verifieringssteg</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -37714,6 +42445,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download features from directory</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner funktioner från katalog</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -37723,6 +42458,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download features from directory</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner funktioner från katalog</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Alt+F2</Shortcut>
@@ -37739,6 +42478,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download one feature</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner en funktion</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -37748,6 +42491,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download one feature</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner en funktion</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Shift+F2</Shortcut>
@@ -37764,6 +42511,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Create data processor templates</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skapa dataprocessormallar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -37773,6 +42524,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Create data processor templates</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skapa dataprocessormallar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СоздатьШаблоныОбработокКоманда</Action>
@@ -37873,6 +42628,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Run selected scenario</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör valt scenario</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Alt+F5</Shortcut>
@@ -38066,6 +42825,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open feature file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna feature-fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38075,6 +42838,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open feature file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna feature-fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Shift+F7</Shortcut>
@@ -38091,6 +42858,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Start user actions recording</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta inspelning av användaråtgärder</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38100,6 +42871,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Start user actions recording</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta inspelning av användaråtgärder</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+R</Shortcut>
@@ -38116,6 +42891,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>End recording user actions</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avsluta inspelning av användaråtgärder</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38125,6 +42904,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>End recording user actions</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avsluta inspelning av användaråtgärder</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗавершитьЗаписьДействийПользователяКнопка</Action>
@@ -38317,6 +43100,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Remember test client form state</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kom ihåg testklientformulärets tillstånd</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38326,6 +43113,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Remember test client form state</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kom ihåg testklientformulärets tillstånd</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗапомнитьСостояниеФормыTestClientКнопка</Action>
@@ -38341,6 +43132,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Forget test client form state</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Glöm testklientformulärets tillstånd</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38350,6 +43145,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Forget test client form state</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Glöm testklientformulärets tillstånd</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗабытьСостояниеФормыTestClientКнопка</Action>
@@ -38365,6 +43164,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get gherkin form changes</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta Gherkin-formulärändringar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38374,6 +43177,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get whole form changes as steps</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta hela formulärändringar som steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПолучитьИзмененияФормыGherkinКнопка</Action>
@@ -38389,6 +43196,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get JSON form changes</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta JSON-formulärändringar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38398,6 +43209,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get JSON form changes</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta JSON-formulärändringar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -38412,6 +43227,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse tree to features</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop trädet till funktioner</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38421,6 +43240,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse tree to features</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop trädet till funktioner</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СвернутьДеревоДоФич</Action>
@@ -38436,6 +43259,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse tree to scenarios</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop trädet till scenarier</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -38445,6 +43272,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse tree to features</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop trädet till funktioner</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СвернутьДеревоДоСценариев</Action>
@@ -38545,6 +43376,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Check video recording</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kontrollera videoinspelning</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПроверитьЧтоЗаписьВидеоБудетРаботать</Action>
@@ -38998,6 +43833,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save test clients</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara testklienter</v8:content>
+				</v8:item>
 			</ToolTip>
 			<Action>СохранитьКлиентовТестированияКоманда</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -39187,6 +44026,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Start recording</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta inspelning</v8:content>
 				</v8:item>
 			</Title>
 			<ToolTip>
@@ -39816,6 +44659,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Start feature</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta feature</v8:content>
+				</v8:item>
 			</Title>
 			<Shortcut>Ctrl+Alt+F5</Shortcut>
 			<Action>ВыполнитьФичуФорма</Action>
@@ -39831,6 +44678,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -39840,6 +44691,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу1</Action>
@@ -39855,6 +44710,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature2</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion2</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -39864,6 +44723,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу2</Action>
@@ -39879,6 +44742,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature3</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion3</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -39888,6 +44755,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу3</Action>
@@ -39903,6 +44774,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature4</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion4</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -39912,6 +44787,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу4</Action>
@@ -39927,6 +44806,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature5</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion5</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -39936,6 +44819,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу5</Action>
@@ -39951,6 +44838,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature6</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion6</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -39960,6 +44851,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу6</Action>
@@ -39975,6 +44870,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature7</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion7</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -39984,6 +44883,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу7</Action>
@@ -39999,6 +44902,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature8</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion8</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -40008,6 +44915,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу8</Action>
@@ -40023,6 +44934,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature9</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion9</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -40032,6 +44947,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Download recent feature1</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda ner senaste funktion1</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНедавнююФичу9</Action>
@@ -40227,6 +45146,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>vi</v8:lang>
 					<v8:content>Chạy kịch bản này với sự hiện bước</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör detta scenario från aktuellt steg</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -40240,6 +45163,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>vi</v8:lang>
 					<v8:content>Chạy kịch bản này với sự hiện bước</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör detta scenario från aktuellt steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+F5</Shortcut>
@@ -40256,6 +45183,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Run this scenario from current step and continue</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör detta scenario från aktuellt steg och fortsätt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -40269,6 +45200,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>vi</v8:lang>
 					<v8:content>Chạy kịch bản này với sự hiện bước</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör detta scenario från aktuellt steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Shift+F5</Shortcut>
@@ -40992,6 +45927,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open features directory</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna feature-katalog</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41001,6 +45940,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open features directory</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna feature-katalog</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+F7</Shortcut>
@@ -41017,6 +45960,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reload and run the scenario</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda om och kör scenariot</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41026,6 +45973,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reload and run the scenario</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda om och kör scenariot</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Alt+F6</Shortcut>
@@ -41042,6 +45993,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Pause recording user actions</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Pausa inspelning av användaråtgärder</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41051,6 +46006,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Pause recording user actions</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Pausa inspelning av användaråtgärder</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПриостановитьЗаписьДействийПользователя</Action>
@@ -41066,6 +46025,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Continue recording user actions</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fortsätt inspelning av användaråtgärder</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41075,6 +46038,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Continue recording user actions</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fortsätt inspelning av användaråtgärder</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПродолжитьЗаписьДействийПользователя</Action>
@@ -41090,6 +46057,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show/hide file path</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj filsökväg</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41099,6 +46070,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide file path</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj filsökväg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьПутьКФайлу</Action>
@@ -41114,6 +46089,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide snippet</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj kodavsnitt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41123,6 +46102,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide snippet</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj kodavsnitt</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьСнипет</Action>
@@ -41138,6 +46121,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide snippet address</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj kodavsnittsadress</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41147,6 +46134,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide snippet address</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj kodavsnittsadress</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьАдресСнипета</Action>
@@ -41162,6 +46153,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide real procedure string</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj faktisk procedursträng</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41171,6 +46166,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide real procedure string</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj faktisk procedursträng</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьСтрокаРеальнойПроцедуры</Action>
@@ -41186,6 +46185,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show/Hide all columns</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/Dölj alla kolumner</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41195,6 +46198,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide all columns</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj alla kolumner</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьВсеКолонки</Action>
@@ -41387,6 +46394,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide string ID</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj sträng-ID</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41396,6 +46407,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide StringID</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj StringID</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСкрытьИДСтроки</Action>
@@ -41411,6 +46426,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Execute arbitrary code</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör godtycklig kod</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41420,6 +46439,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Execute arbitrary code</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör godtycklig kod</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВыполнитьПроизвольныйКод</Action>
@@ -41611,6 +46634,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Add line to libraries list</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg till rad i bibliotekslistan</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -41620,6 +46647,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Add line to libraries list</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg till rad i bibliotekslistan</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ДобавитьСтрокуВСписокБиблиотек</Action>
@@ -42074,6 +47105,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Clear generated scenario</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rensa genererat scenario</v8:content>
+				</v8:item>
 			</ToolTip>
 			<Action>ОчиститьСгенерированныйСценарий</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -42088,6 +47123,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get current form element validation in steps</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta aktuell formulärelementvalidering i steg</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42097,6 +47136,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get current form element validation in steps</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta aktuell formulärelementvalidering i steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Shift+C</Shortcut>
@@ -42199,6 +47242,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Translate text into another language</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Översätt text till ett annat språk</v8:content>
+				</v8:item>
 			</ToolTip>
 			<Action>ПеревестиТекстНаДругойЯзык</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -42213,6 +47260,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Expand all line tree service</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Expandera alla rader trädtjänst</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42222,6 +47273,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Expand all line tree service</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Expandera alla rader trädtjänst</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>РазвернутьВсеСтрокиДереваСлужебный</Action>
@@ -42237,6 +47292,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reset SikuliX server connection</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Återställ SikuliX-serveranslutning</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42246,6 +47305,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reset connection SikuliX server</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Återställ anslutning SikuliX-server</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СброситьПодключениеSikuliXСервера</Action>
@@ -42261,6 +47324,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse tree to steps</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop trädet till steg</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42270,6 +47337,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse tree to steps</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop trädet till steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СвернутьДеревоДоШагов</Action>
@@ -42285,6 +47356,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show/Hide variables board</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/Dölj variabeltavla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42294,6 +47369,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show hide variables board</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj variabeltavla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Alt+W</Shortcut>
@@ -42310,6 +47389,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Refresh variables board</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera variabeltavla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42319,6 +47402,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Refresh variables board</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera variabeltavla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ОбновитьТаблоПеременных</Action>
@@ -42334,6 +47421,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Stop</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stopp</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42343,6 +47434,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Stop</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stopp</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -42362,6 +47457,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Move to next line with error</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Flytta till nästa rad med fel</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42371,6 +47470,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Move to next line with error</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Flytta till nästa rad med fel</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>F8</Shortcut>
@@ -42387,6 +47490,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save settings to file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara inställningar till fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42396,6 +47503,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save settings to file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara inställningar till fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВыгрузитьНастройкиВФайл</Action>
@@ -42411,6 +47522,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load settings from file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda inställningar från fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42420,6 +47535,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load settings from file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda inställningar från fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьНастройкиИзФайла</Action>
@@ -42435,6 +47554,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42444,6 +47567,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close variables board</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng variabeltavla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗакрытьТаблоПеременных</Action>
@@ -42459,6 +47586,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Scenario generator</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Scenariogenerator</v8:content>
+				</v8:item>
 			</Title>
 			<Action>ОткрытьФормуГенератораСценариев</Action>
 			<CurrentRowUse>DontUse</CurrentRowUse>
@@ -42473,6 +47604,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>by default</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>som standard</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42482,6 +47617,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Set default value</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange standardvärde</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -42501,6 +47640,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Speak</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Tala</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42510,6 +47653,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Voice test</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rösttest</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ТестГолосаПроизнести</Action>
@@ -42525,6 +47672,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Install service programs</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Installera serviceprogram</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42534,6 +47685,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Utilities allow you to highlight the mouse pointer, draw arrows to form elements. Required  for some SikuliX steps.</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Verktygen gör det möjligt att markera muspekaren, rita pilar till formulärelement. Krävs för vissa SikuliX-steg.</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>УстановитьСервисныеУтилиты</Action>
@@ -42549,6 +47704,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open step definition</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna stegdefinition</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42558,6 +47717,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open step definition</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna stegdefinition</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+I</Shortcut>
@@ -42575,6 +47738,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Create main scheme</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skapa huvudschema</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42584,6 +47751,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Fill in standard search profiles</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fyll i standardsökprofiler</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗаполнитьТиповыеПрофилиЦветов</Action>
@@ -42599,6 +47770,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Highlight code like embedded language</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera kod som inbäddat språk</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42610,6 +47785,12 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Highlight code like embedded language:
+    |' code '|
+</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Markera kod som inbäddat språk:
     |' code '|
 </v8:content>
 				</v8:item>
@@ -42628,6 +47809,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Comment lines of the script</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kommentera rader i skriptet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42637,6 +47822,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Comment lines of the script</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kommentera rader i skriptet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Num /</Shortcut>
@@ -42653,6 +47842,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Set test client window size</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange testklientfönsterstorlek</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42662,6 +47855,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Set test client window size</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange testklientfönsterstorlek</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗадатьРазмерОкнаКлиентаТестирования</Action>
@@ -42677,6 +47874,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Check scenarios for duplication</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kontrollera scenarier för dubbletter</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42686,6 +47887,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Check scenarios for duplication</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kontrollera scenarier för dubbletter</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПроверитьДублированиеСценариев</Action>
@@ -42705,6 +47910,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>ro</v8:lang>
 					<v8:content>Chrome</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Chrome</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42714,6 +47923,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Google Chrome startup command</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Google Chrome startkommando</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>КомандаЗапускаChrome</Action>
@@ -42733,6 +47946,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>ro</v8:lang>
 					<v8:content>Chrome+debug</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Chrome+debug</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42742,6 +47959,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Google Chrome startup command with debugging</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Google Chrome startkommando med felsökning</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>КомандаЗапускаChromeСОтладкой</Action>
@@ -42757,6 +47978,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Go to Vanessa Editor</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gå till Vanessa-redigeraren</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42766,6 +47991,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Go to Vanessa Editor</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gå till Vanessa-redigeraren</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -42785,6 +48014,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Go to step tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gå till stegträdet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42794,6 +48027,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Go to step tree</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gå till stegträdet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПерейтиВДеревоШагов</Action>
@@ -42809,6 +48046,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Execute selected lines</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör markerade rader</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42818,6 +48059,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Execute selected lines</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kör markerade rader</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВыполнитьВыделенныеСтроки</Action>
@@ -42833,6 +48078,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Cut</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Klipp ut</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42842,6 +48091,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Cut (Ctrl+X)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Klipp ut (Ctrl+X)</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -42857,6 +48110,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Copy</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kopiera</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42866,6 +48123,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Copy (Ctrl+C)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kopiera (Ctrl+C)</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -42881,6 +48142,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Paste</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Klistra in</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42890,6 +48155,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Paste (Ctrl+V)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Klistra in (Ctrl+V)</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -42905,6 +48174,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Undo</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ångra</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42914,6 +48187,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Undo</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ångra</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Z</Shortcut>
@@ -42935,6 +48212,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Redo</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gör om</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42944,6 +48225,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Redo</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Gör om</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Y</Shortcut>
@@ -42965,6 +48250,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find (Ctrl+F)</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök (Ctrl+F)</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -42974,6 +48263,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Search (Ctrl+F)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök (Ctrl+F)</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -42993,6 +48286,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find previous</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök föregående</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43002,6 +48299,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find previous</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök föregående</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43021,6 +48322,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find next</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök nästa</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43030,6 +48335,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Find next</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök nästa</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43049,6 +48358,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Replace (Ctrl+H)</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ersätt (Ctrl+H)</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43058,6 +48371,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Replace (Ctrl+H)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ersätt (Ctrl+H)</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43077,6 +48394,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43086,6 +48407,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43105,6 +48430,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>1</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>1</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43114,6 +48443,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse to the first level</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop till första nivån</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -43129,6 +48462,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>2</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>2</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43138,6 +48475,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse to the second level</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop till andra nivån</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -43153,6 +48494,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>3</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>3</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43162,6 +48507,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse to third level</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop till tredje nivån</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -43177,6 +48526,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Expand all</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Expandera alla</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43186,6 +48539,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Expand all</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Expandera alla</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43205,6 +48562,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Zoom in</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Zooma in</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43214,6 +48575,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Zoom in</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Zooma in</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43233,6 +48598,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Zoom out</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Zooma ut</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43242,6 +48611,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Zoom out</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Zooma ut</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43261,6 +48634,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reset zoom</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Återställ zoom</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43270,6 +48647,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reset zoom</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Återställ zoom</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -43285,6 +48666,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Set/remove a breakpoint</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sätt/ta bort en brytpunkt</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43294,6 +48679,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Set/remove a breakpoint</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sätt/ta bort en brytpunkt</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>F9</Shortcut>
@@ -43310,6 +48699,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Remove all breakpoints</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta bort alla brytpunkter</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43319,6 +48712,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Remove all breakpoints</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta bort alla brytpunkter</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorRemoveBreakPoints</Action>
@@ -43334,6 +48731,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>4</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>4</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43343,6 +48744,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse to the fourth level</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop till fjärde nivån</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -43358,6 +48763,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>5</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>5</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43367,6 +48776,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Collapse to the fifth level</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Fäll ihop till femte nivån</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСтандартныеКоманды</Action>
@@ -43382,6 +48795,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43391,6 +48808,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save file (ctrl+S)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara fil (ctrl+S)</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСохранитьФайл</Action>
@@ -43406,6 +48827,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>1C:Enterprise</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>1C:Enterprise</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43414,6 +48839,10 @@ Click on the hyperlink for more details.</v8:content>
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>1C:Enterprise</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>1C:Enterprise</v8:content>
 				</v8:item>
 			</ToolTip>
@@ -43430,6 +48859,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Main theme</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Huvudtema</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43439,6 +48872,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Main theme</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Huvudtema</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorТема_vs</Action>
@@ -43454,6 +48891,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Dark theme</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Mörkt tema</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43463,6 +48904,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Dark theme</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Mörkt tema</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorТема_vsdark</Action>
@@ -43478,6 +48923,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>High contrast</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hög kontrast</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43487,6 +48936,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>High contrast</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hög kontrast</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorТема_hcblack</Action>
@@ -43502,6 +48955,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show / hide service variables</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa / dölj servicevariabler</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43511,6 +48968,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show service variables</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa servicevariabler</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьСлужебныеПеременные</Action>
@@ -43526,6 +48987,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Use the data of the current form when adding steps</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Använd data från det aktuella formuläret vid tillägg av steg</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43535,6 +49000,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Use the data of the current form when adding steps</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Använd data från det aktuella formuläret vid tillägg av steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorИспользоватьДанныеТекущейФормыПриПодбореШагов</Action>
@@ -43550,6 +49019,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show subscript lines</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa underskriptrader</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43559,6 +49032,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show subscript lines</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa underskriptrader</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПоказыватьСтрокиПодсценариев</Action>
@@ -43574,6 +49051,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get check for user messages in steps</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta kontroll av användarmeddelanden i steg</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43583,6 +49064,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Add User Post Validation</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg till användarpostvalidering</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ДобавитьПроверкуСообщенийПользователя</Action>
@@ -43598,6 +49083,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show list of breakpoints</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa lista över brytpunkter</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43607,6 +49096,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show list of breakpoints</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa lista över brytpunkter</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПоказатьСписокТочекОстанова</Action>
@@ -43622,6 +49115,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show/hide directory tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj katalogträd</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43631,6 +49128,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show/hide directory tree</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj katalogträd</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПоказатьСкрытьДеревоКаталогов</Action>
@@ -43646,6 +49147,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Clear line coloring</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rensa radfärgning</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43655,6 +49160,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Clear line coloring</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Rensa radfärgning</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Alt+C</Shortcut>
@@ -43671,6 +49180,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get startup string from command line</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta startsträng från kommandoraden</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43680,6 +49193,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get start string</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta startsträng</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПолучитьСтрокуЗапуска</Action>
@@ -43695,6 +49212,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show code miniature</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa kodminiatyr</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43704,6 +49225,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show code miniature</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa kodminiatyr</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПоказыватьМиниатюруКода</Action>
@@ -43719,6 +49244,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show/hide panel buttons</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa/dölj panelknappar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43728,6 +49257,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Setting the visibility of the editor panel buttons</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ange synligheten för redigerarens panelknappar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>НастройкаВидимостиКнопокПанелиРедактора</Action>
@@ -43742,6 +49275,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Test</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Test</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43751,6 +49288,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Mouse click backlight test</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Test av musklickmarkering</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ТестПодсветкиКликаМышки</Action>
@@ -43765,6 +49306,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open subscript in a new tab</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna underskript i ny flik</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43774,6 +49319,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open feature file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna feature-fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>F7</Shortcut>
@@ -43790,6 +49339,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>New scenario</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Nytt scenario</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43799,6 +49352,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>New scenario</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Nytt scenario</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+N</Shortcut>
@@ -43818,6 +49375,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close tab</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng flik</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43827,6 +49388,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Close tab</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stäng flik</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+W</Shortcut>
@@ -43842,6 +49407,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open in player</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna i spelare</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43851,6 +49420,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open in player</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna i spelare</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ТестГолосаОткрытьВПлеере</Action>
@@ -43866,6 +49439,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Working with git</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Arbeta med git</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43875,6 +49452,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Working with git</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Arbeta med git</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Alt+G</Shortcut>
@@ -43890,6 +49471,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Refresh</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43899,6 +49484,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Refresh</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -43918,6 +49507,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Add to index</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Lägg till i index</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43927,6 +49520,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Stage Selected</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Staga markerade</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ДеревоGitДобавитьВИндекс</Action>
@@ -43941,6 +49538,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Remove from index</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ta bort från index</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43950,6 +49551,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Unstage Selected</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Avstaga markerade</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ДеревоGitУбратьИзИндекса</Action>
@@ -43964,6 +49569,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Commit</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Commit</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43972,6 +49581,10 @@ Click on the hyperlink for more details.</v8:content>
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>Commit</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>Commit</v8:content>
 				</v8:item>
 			</ToolTip>
@@ -43987,6 +49600,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Git settings</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Git-inställningar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -43996,6 +49613,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Settings</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Inställningar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ДеревоGitНастройки</Action>
@@ -44010,6 +49631,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Branch selection</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Grenval</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44019,6 +49644,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Branch selection</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Grenval</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ДеревоGitВыборВетки</Action>
@@ -44033,6 +49662,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show differences in editor separately</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa skillnader i redigeraren separat</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44042,6 +49675,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show differences in editor separately</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa skillnader i redigeraren separat</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПоказыватьРазличияВРедактореОтдельно</Action>
@@ -44056,6 +49693,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save file as</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara fil som</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44065,6 +49706,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save file as</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara fil som</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorСохранитьФайлКак</Action>
@@ -44079,6 +49724,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Pull</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Pull</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44087,6 +49736,10 @@ Click on the hyperlink for more details.</v8:content>
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>Pull</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>Pull</v8:content>
 				</v8:item>
 			</ToolTip>
@@ -44102,6 +49755,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Push</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Push</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44110,6 +49767,10 @@ Click on the hyperlink for more details.</v8:content>
 				</v8:item>
 				<v8:item>
 					<v8:lang>en</v8:lang>
+					<v8:content>Push</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
 					<v8:content>Push</v8:content>
 				</v8:item>
 			</ToolTip>
@@ -44125,6 +49786,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Previous diff</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Föregående skillnad</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44134,6 +49799,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Previous diff</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Föregående skillnad</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -44153,6 +49822,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Next diff</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Nästa skillnad</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44162,6 +49835,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Next diff</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Nästa skillnad</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -44181,6 +49858,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Syntax check</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Syntaxkontroll</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44190,6 +49871,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Syntax checking in the editor</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Syntaxkontroll i redigeraren</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПроверкаСинтаксисаВРедакторе</Action>
@@ -44204,6 +49889,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Print steps tree</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skriv ut stegträd</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44213,6 +49902,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Print the tree</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skriv ut trädet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВывестиДеревоНаПечать</Action>
@@ -44227,6 +49920,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Test data generator</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Testdatagenerator</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44236,6 +49933,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open tool prepare and load data</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna verktyg för förberedelse och laddning av data</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ОткрытьИнструментПодготовкаИЗагрузкаДанных</Action>
@@ -44250,6 +49951,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Compare current settings with file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Jämför aktuella inställningar med fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44259,6 +49964,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Compare current settings with file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Jämför aktuella inställningar med fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СравнитьТекущиеНастройкиСФайлом</Action>
@@ -44273,6 +49982,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Create instructions for describing elements</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skapa instruktioner för att beskriva element</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44282,6 +49995,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Create instructions for describing elements</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Skapa instruktioner för att beskriva element</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СоздатьИнструкциюПоОписаниюЭлементов</Action>
@@ -44296,6 +50013,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Enable/disable video recording</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Aktivera/inaktivera videoinspelning</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44305,6 +50026,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Enable/disable video recording</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Aktivera/inaktivera videoinspelning</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВключитьВыключитьЗаписьВидео</Action>
@@ -44319,6 +50044,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Compare with another feature file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Jämför med en annan feature-fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44328,6 +50057,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Compare with another feature file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Jämför med en annan feature-fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СравнитьСДругимФичаФайлом</Action>
@@ -44342,6 +50075,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save the state of the current test client form to a file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara tillståndet för det aktuella testklientformuläret till en fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44351,6 +50088,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save the state of the current test client form to a file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara tillståndet för det aktuella testklientformuläret till en fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СохранитьСостояниеТекущейФормыКлиентаТестированияВФайл</Action>
@@ -44365,6 +50106,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save the state of all test client forms to a file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara tillståndet för alla testklientformulär till en fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44374,6 +50119,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save the state of all test client forms to a file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara tillståndet för alla testklientformulär till en fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СохранитьСостояниеВсехФормКлиентаТестированияВФайл</Action>
@@ -44388,6 +50137,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show Allure report</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa Allure-rapport</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44397,6 +50150,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show Allure report</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa Allure-rapport</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Shift+A</Shortcut>
@@ -44412,6 +50169,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>View Markdown file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa Markdown-fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44421,6 +50182,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>View Markdown file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa Markdown-fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ОткрытьФайлДокументации</Action>
@@ -44435,6 +50200,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Turn on / off the sound of the script execution</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Slå på/av ljudet för skriptkörning</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44444,6 +50213,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Turn on / off the sound of the script execution</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Slå på/av ljudet för skriptkörning</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВключитьВыключитьОзвучиваниеВыполненияСценария</Action>
@@ -44458,6 +50231,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Speak the current line</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Läs upp aktuell rad</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44467,6 +50244,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Speak the current line</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Läs upp aktuell rad</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Alt+S</Shortcut>
@@ -44482,6 +50263,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show Monaco context menu</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa Monaco snabbmeny</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44491,6 +50276,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Monaco context menu</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Monaco snabbmeny</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorContextMenu</Action>
@@ -44505,6 +50294,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>ru</v8:lang>
 					<v8:content>Проверка подключения к мобильному устройству</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Testa anslutning till mobil enhet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44514,6 +50307,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Test connection to mobile device</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Testa anslutning till mobil enhet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПроверкаПодключенияКМобильномуУстройству</Action>
@@ -44528,6 +50325,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>ru</v8:lang>
 					<v8:content>Запустить мобильный клиент</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta mobilklient</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44537,6 +50338,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Launch mobile client</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta mobilklient</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗапуститьМобильныйКлиент</Action>
@@ -44551,6 +50356,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open the list of lessons</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna lektionslistan</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44560,6 +50369,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open the list of lessons</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna lektionslistan</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorОткрытьСписокУроков</Action>
@@ -44574,6 +50387,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show variable values in editor lines</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa variabelvärden i redigerarens rader</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44583,6 +50400,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show variable values in editor lines</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa variabelvärden i redigerarens rader</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПоказыватьЗначенияПеременныхВСтрокахРедактора</Action>
@@ -44597,6 +50418,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open welcome page</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna välkomstsida</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44606,6 +50431,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show welcome page</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa välkomstsida</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorWelcome</Action>
@@ -44620,6 +50449,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>All editor settings</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Alla redigerarinställningar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44629,6 +50462,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>All editor settings</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Alla redigerarinställningar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorНастройкиРедактора</Action>
@@ -44643,6 +50480,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reset settings of Vanessa Automation</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Återställ inställningar för Vanessa Automation</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44652,6 +50493,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Reset settings</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Återställ inställningar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СброситьНастройкиVanessaAutomation</Action>
@@ -44666,6 +50511,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load from file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda från fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44675,6 +50524,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load a list of testing clients from a file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda en lista med testklienter från en fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьСписокКлиентовТестированияИзФайла</Action>
@@ -44689,6 +50542,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44698,6 +50555,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load item from directory tree</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda objekt från katalogträdet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьЭлементИзДереваКаталогов</Action>
@@ -44712,6 +50573,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>ru</v8:lang>
 					<v8:content>Запустить мобильное приложение</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta mobilapplikation</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44721,6 +50586,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Launch mobile app</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Starta mobilapp</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗапуститьМобильноеПриложение</Action>
@@ -44735,6 +50604,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate mp3 from the catalog of features of the online help</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera mp3 från katalogen med funktioner i onlinehjälpen</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44744,6 +50617,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Generate mp3 from the catalog of features of the online help</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Generera mp3 från katalogen med funktioner i onlinehjälpen</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>СгенерироватьMp3ПоКаталогуФичИнтерактивнойСправки</Action>
@@ -44758,6 +50635,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get the step of opening the navigation link of the current window</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta steget för att öppna navigeringslänken för det aktuella fönstret</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44767,6 +50648,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get the step of opening the navigation link of the current window</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta steget för att öppna navigeringslänken för det aktuella fönstret</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПолучитьШагОткрытияНавигационнойСсылкиТекущегоОкна</Action>
@@ -44781,6 +50666,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get the coordinates of the area for the screenshot</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta koordinaterna för området för skärmbilden</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44790,6 +50679,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get area coordinates</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta områdeskoordinater</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПолучитьКоординатыОбласти</Action>
@@ -44804,6 +50697,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show helper on first run</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa hjälpare vid första körningen</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44813,6 +50710,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show helper on first run</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa hjälpare vid första körningen</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоказатьПомощникПриПервомЗапускеКоманда</Action>
@@ -44827,6 +50728,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Expand all groups in settings</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Expandera alla grupper i inställningar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44836,6 +50741,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Expand all groups in settings</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Expandera alla grupper i inställningar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>РазвернутьВсеГруппыВНастройках</Action>
@@ -44850,6 +50759,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Checking the translation of form elements</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kontroll av översättning av formulärelement</v8:content>
+				</v8:item>
 			</Title>
 			<Action>ПроверкаПереводаЭлементовФормы</Action>
 		</Command>
@@ -44863,6 +50776,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open the HTML Style Editor</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna HTML-stilredigeraren</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44872,6 +50789,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Edit styles</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Redigera stilar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -44891,6 +50812,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Browser settings</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Webbläsarinställningar</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44900,6 +50825,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Browser settings form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Formulär för webbläsarinställningar</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>НастройкиРаботыСБраузером</Action>
@@ -44914,6 +50843,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Header uniqueness check</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kontroll av rubrikens unikhet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44923,6 +50856,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Header uniqueness check</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Kontroll av rubrikens unikhet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПроверкаУникальностиЗаголовков</Action>
@@ -44937,6 +50874,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get the startup line from the command line with log output to the console</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta startraden från kommandoraden med loggutmatning till konsolen</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44946,6 +50887,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get start string</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta startsträng</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПолучитьСтрокуЗапускаСВыводомЛогаВКонсоль</Action>
@@ -44961,6 +50906,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Search for messages to the user for which no translation is specified</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök efter meddelanden till användaren för vilka ingen översättning har angetts</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44970,6 +50919,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Search for messages to the user for which no translation is specified</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök efter meddelanden till användaren för vilka ingen översättning har angetts</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПоискСообщенийПользователюДляКоторыхНеУказанПеревод</Action>
@@ -44984,6 +50937,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>When generating steps, search for form elements by name</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök efter formulärelement efter namn vid generering av steg</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -44993,6 +50950,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>When generating steps, search for form elements by name</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Sök efter formulärelement efter namn vid generering av steg</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПриГенерацииШаговИскатьЭлементыФормыПоИмени</Action>
@@ -45007,6 +50968,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show brief information about the step</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa kort information om steget</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45016,6 +50981,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Show brief information about the step</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Visa kort information om steget</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+Shift+I</Shortcut>
@@ -45031,6 +51000,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get current window check step</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta kontrollsteg för aktuellt fönster</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45040,6 +51013,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get current window check step</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta kontrollsteg för aktuellt fönster</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПолучитьШагПроверкиТекущегоОкна</Action>
@@ -45054,6 +51031,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get form header validation step</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta valideringssteg för formulärrubrik</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45063,6 +51044,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Get form header validation step</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hämta valideringssteg för formulärrubrik</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ПолучитьШагПроверкиШапкиФормы</Action>
@@ -45077,6 +51062,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Restarts as a test manager</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Startar om som testhanterare</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45086,6 +51075,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Restarts as a test manager</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Startar om som testhanterare</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaEditorПерезапуститьКакМенеджерТестирования</Action>
@@ -45100,6 +51093,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save The Standard HTML Layout</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara standard HTML-layout</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45109,6 +51106,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save the default option styles to a file and select it</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara standardalternativstilarna till en fil och välj den</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Picture>
@@ -45128,6 +51129,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Update mp3 cache in directory with current mp3 cache</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Uppdatera mp3-cache i katalog med aktuell mp3-cache</v8:content>
+				</v8:item>
 			</Title>
 			<Action>ОбновитьКешMp3ВКаталогеПоТекущемуКешуMp3</Action>
 		</Command>
@@ -45141,6 +51146,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Replace a verification step by name with a verification step by title and vice versa</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ersätt ett verifieringssteg efter namn med ett verifieringssteg efter titel och vice versa</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45150,6 +51159,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Replace a verification step by name with a verification step by title and vice versa</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ersätt ett verifieringssteg efter namn med ett verifieringssteg efter titel och vice versa</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Shortcut>Ctrl+J</Shortcut>
@@ -45165,6 +51178,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Handler for enabling display of help for an element under the mouse cursor</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Hanterare för att aktivera visning av hjälp för ett element under muspekaren</v8:content>
+				</v8:item>
 			</Title>
 			<Shortcut>Alt+H</Shortcut>
 			<Action>ОбработчикВключенияПоказаСправкиПоЭлементуПодКурсоромМышки</Action>
@@ -45179,6 +51196,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open Layout Serializer</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna layoutserialiserare</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45188,6 +51209,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open Layout Serializer</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna layoutserialiserare</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ОткрытьСериализаторМакетов</Action>
@@ -45202,6 +51227,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Authorization (1C speech synthesis)</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Auktorisering (1C-talsyntes)</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45211,6 +51240,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Authorization (1C speech synthesis)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Auktorisering (1C-talsyntes)</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗаписьВидео1САвторизацияВСервисе</Action>
@@ -45225,6 +51258,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Save variables to file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Spara variabler till fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45234,6 +51271,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Upload variables to a file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda upp variabler till en fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВыгрузитьПеременные</Action>
@@ -45248,6 +51289,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Upload variables to the rollback system</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda upp variabler till återställningssystemet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45257,6 +51302,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Upload variables to the rollback system</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda upp variabler till återställningssystemet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ВыгрузитьВСистемуОтката</Action>
@@ -45271,6 +51320,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load variables from the rollback system</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda variabler från återställningssystemet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45280,6 +51333,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load variables from the rollback system</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda variabler från återställningssystemet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьИзСистемыОтката</Action>
@@ -45294,6 +51351,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Information about the rollback system</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Information om återställningssystemet</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45303,6 +51364,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Information about the rollback system</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Information om återställningssystemet</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>VanessaИнформацияОСистемеОтката</Action>
@@ -45318,6 +51383,10 @@ Click on the hyperlink for more details.</v8:content>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load variables from file</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda variabler från fil</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -45327,6 +51396,10 @@ Click on the hyperlink for more details.</v8:content>
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Load variables from a file</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Ladda variabler från en fil</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ЗагрузитьПеременные</Action>

--- a/VanessaAutomation/Forms/ЧтениеПараметровПриОткрытии/Ext/Form.xml
+++ b/VanessaAutomation/Forms/ЧтениеПараметровПриОткрытии/Ext/Form.xml
@@ -36,6 +36,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Metadata full name</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Metadata fullständigt namn</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -54,6 +58,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>File name used</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Använt filnamn</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -74,6 +82,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Editor version</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Redigeringsversion</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:string</v8:Type>
@@ -93,6 +105,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Self test mode</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Självtestläge</v8:content>
+				</v8:item>
 			</Title>
 			<Type>
 				<v8:Type>xs:boolean</v8:Type>
@@ -107,6 +123,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Synchronous calls not allowed</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Synkrona anrop inte tillåtna</v8:content>
 				</v8:item>
 			</Title>
 			<Type>
@@ -125,6 +145,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Open main form</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna huvudformuläret</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -134,6 +158,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Open main form</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Öppna huvudformuläret</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ОткрытьОсновнуюФорму</Action>
@@ -148,6 +176,10 @@
 					<v8:lang>en</v8:lang>
 					<v8:content>Stop script execution</v8:content>
 				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stoppa skriptkörning</v8:content>
+				</v8:item>
 			</Title>
 			<ToolTip>
 				<v8:item>
@@ -157,6 +189,10 @@
 				<v8:item>
 					<v8:lang>en</v8:lang>
 					<v8:content>Stop script execution</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>sv</v8:lang>
+					<v8:content>Stoppa skriptkörning</v8:content>
 				</v8:item>
 			</ToolTip>
 			<Action>ОстановитьВыполнениеСценариев</Action>

--- a/locales/Messages/Templates/sv/Ext/Template.xml
+++ b/locales/Messages/Templates/sv/Ext/Template.xml
@@ -23402,7 +23402,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Bearbetningssteg hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23429,7 +23429,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sökvägen &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23456,7 +23456,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Okänt fel.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23483,7 +23483,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktivera tillägget &lt;VanessaExt&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23510,7 +23510,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Feature-fil eller katalog för feature-filer har inte angetts för inläsning.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23537,7 +23537,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Version</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23564,7 +23564,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>PIDTestClient</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23591,7 +23591,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>CurrentValueLayout</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23618,7 +23618,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ReferenceValueLayout</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23645,7 +23645,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>CurrentValueTable</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23672,7 +23672,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ReferenceValueTable</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23699,7 +23699,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>RowsSearchedInTable</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23726,7 +23726,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>CurrentReportValue</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23753,7 +23753,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23780,7 +23780,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ActiveFormState</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23807,7 +23807,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>AllFormsState</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23834,7 +23834,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>EventLog</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23861,7 +23861,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Skillnader</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23888,7 +23888,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>DataAboutNetworkConnections</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23915,7 +23915,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ProcessesData</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23942,7 +23942,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Spara ändringar?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23969,7 +23969,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det finns osparade ändringar. Är du säker?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -23996,7 +23996,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sparar fil.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24023,7 +24023,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fliken med rubriken &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24050,7 +24050,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Spara filen för att utföra denna åtgärd.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24077,7 +24077,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Översättningsproblem hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24104,7 +24104,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tomma rader i bibliotekslistan är inte tillåtna.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24131,7 +24131,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stöds inte i Linux OS.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24158,7 +24158,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Commit-text har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24185,7 +24185,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inga ändringar att spara.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24212,7 +24212,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det aktuella fältet &lt;%1&gt; är inte en tabell.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24239,7 +24239,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ange nytt grennamn</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24266,7 +24266,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Skapa ny</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24293,7 +24293,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönstertexten &lt;%1&gt; matchar inte mönstret &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24320,7 +24320,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tunn</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24347,7 +24347,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönstret som innehåller formuläret &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24374,7 +24374,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklientdata</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24401,7 +24401,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>VariablesData</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24428,7 +24428,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönstret som innehåller formuläret &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24455,7 +24455,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Steget &lt;%1&gt; misslyckades i Försök/Undantag-sektionen. Trädrad nr %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24482,7 +24482,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Steget som misslyckades i Försök/Undantag-sektionen hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24509,7 +24509,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönsterlistan för processen &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24536,7 +24536,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Felaktig åtgärd med bilden &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24563,7 +24563,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Komponenten VanessaExt installerades inte korrekt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24590,7 +24590,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Textutskriften misslyckades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24617,7 +24617,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kommandot &lt;%1&gt; kunde inte köras.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24644,7 +24644,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ogiltigt statusvärde för scenariot &lt;%1&gt; skickades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24671,7 +24671,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel uppstod vid inläsning av feature-filer.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24698,7 +24698,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hämta formulärändringar i stegformat</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24725,7 +24725,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hämta hela formulärets tillstånd i stegformat</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24752,7 +24752,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tyst installation av den externa komponenten VanessaExt har utförts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24779,7 +24779,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Okänd typ av parametern &lt;%1&gt; i strängen: &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24806,7 +24806,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklienten startades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24833,7 +24833,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En befintlig testklient är ansluten.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24860,7 +24860,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Analys av feature-filer.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24887,7 +24887,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stegträd</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24914,7 +24914,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Antal parametrar stämmer inte överens i steget &lt;%1&gt; och i dess översättning: &lt;%2&gt; och &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24941,7 +24941,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sökvägen för att spara skärmbilder har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24968,7 +24968,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktuella inställningar</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -24995,7 +24995,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Jämförelse av inställningar och fil</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25022,7 +25022,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ingen loop hittades att avbryta.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25049,7 +25049,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktuellt formulärattribut &lt;%1&gt; är: %2, och förväntat var: %3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25076,7 +25076,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktuellt värde för cellen &lt;%1&gt; i tabellen &lt;%2&gt; är: %3, och förväntat var: %4</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25103,7 +25103,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktuellt värde för cellen i tabellen &lt;%1&gt; är: %2, och förväntat var: %3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25130,7 +25130,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Före stegkörning</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25157,7 +25157,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Efter stegkörning</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25184,7 +25184,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte fastställa versionen av filen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25211,7 +25211,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Beskrivning av startfilparametrar för Vanessa Automation från kommandoraden.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25238,7 +25238,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Mallen för denna fil kan erhållas genom att exportera Vanessa Automation-inställningarna till filen VAParams.json.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25265,7 +25265,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Denna fil skapades automatiskt baserat på formulärdata i Vanessa Automation. Skicka pull requests till formulärfältens verktygstips.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25292,7 +25292,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För att kopiera information till urklipp måste du aktivera tillägget &lt;VanessaExt&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25319,7 +25319,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Bakgrundsjobb avslutades inte inom &lt;%1&gt; sekunder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25346,7 +25346,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönstret &lt;%1&gt; innehåller &lt;%2&gt; formulär.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25373,7 +25373,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Länken för rubriken &lt;%1&gt; hittades inte bland länkarna &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25400,7 +25400,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Modalt dialogfönster med objektinformation hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25427,7 +25427,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte beräkna uttrycket på testklientens sida.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25454,7 +25454,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte mata ut aktuella formulärdata från testklienten.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25481,7 +25481,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Värden för element i fönstret &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25508,7 +25508,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte utvärdera uttrycket i testklientens aktuella formulärkontext.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25535,7 +25535,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte köra uttrycket i testklientens aktuella formulärkontext.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25562,7 +25562,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tillägget med namnet &lt;%1&gt; är inte installerat.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25589,7 +25589,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tillägget med namnet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25616,7 +25616,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ett fel uppstod vid inställning av flaggor för tillägget &lt;%1&gt;: &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25643,7 +25643,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välj fönster.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25670,7 +25670,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte konvertera &quot;ogg&quot;-fil till &quot;mp3&quot;. Kommando:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25697,7 +25697,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte konvertera pdf till bild. Kommando:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25724,7 +25724,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta skillnaden mellan bilderna. Kommando:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25751,7 +25751,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta animationen av skillnaden mellan bilderna. Kommando:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25778,7 +25778,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testhanteraren körs inte under Linux. Aktuella OS-data: &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25805,7 +25805,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Rad nr %1 i kalkylbladsdokumentet hittades inte i förlagan.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25832,7 +25832,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sökvägen till TTS-motorprocessorn har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25859,7 +25859,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Videoinspelning är aktiverad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25886,7 +25886,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Videoinspelning är inaktiverad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25913,7 +25913,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välj feature-fil.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25940,7 +25940,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Jämförelse med %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25967,7 +25967,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktuell fil</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -25994,7 +25994,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte utföra tyst installation av VanessaExt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26021,7 +26021,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välj filnamn.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26048,7 +26048,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stegfortsättning anropades, men stegkörningen var inte stoppad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26075,7 +26075,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Omstart av testklient, tidigare startad process hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26102,7 +26102,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tidigare startad 1C-process hittades: &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26129,7 +26129,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönster för licensinhämtning hittades. Process &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26156,7 +26156,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>PID för testklienten med namnet &lt;%1&gt; är inte definierad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26183,7 +26183,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation kunde inte hitta knappen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26210,7 +26210,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte klicka på UI Automation-elementet. Elementet är osynligt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26237,7 +26237,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte. PID &lt;%1&gt;, rubrik &lt;%2&gt;, typ &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26264,7 +26264,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte. PID &lt;%1&gt;, rubrik &lt;%2&gt;, typ &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26291,7 +26291,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade &lt;%1&gt; UI Automation-element med angiven data: PID &lt;%1&gt;&lt;%2&gt;, rubrik &lt;%3&gt;, typ &lt;%4&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26318,7 +26318,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Windows-registret innehåller inte sökvägen till webbläsaren Google Chrome. Ange sökvägen manuellt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26345,7 +26345,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenariouppläsning aktiverad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26372,7 +26372,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenariouppläsning inaktiverad</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26399,7 +26399,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel vid beräkning av variabelvärdet &lt;%1&gt;, uttryck &lt;%2&gt;. Felmeddelande: &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26426,7 +26426,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel vid beräkning av uttrycksvärdet &lt;%1&gt;. Felmeddelande: &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26453,7 +26453,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel vid beräkning av uttrycksvariabeln &lt;%1&gt;. Variabeltabellen hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26480,7 +26480,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att fältet &lt;%2&gt; skulle ha värdet &lt;%3&gt;. Aktuellt värde &lt;%4&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26507,7 +26507,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att fältet &lt;%2&gt; skulle ha ett annat värde än &lt;%3&gt;. Aktuellt värde &lt;%4&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26534,7 +26534,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>OSProcessesData</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26561,7 +26561,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>VariableValues</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26588,7 +26588,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>NetworkConnectionsData</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26615,7 +26615,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sökvägen till adb-programfilen har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26642,7 +26642,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalogen för mp3-filcache har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26669,7 +26669,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte. PID &lt;%1&gt;, rubrik &lt;%2&gt;, typ &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26696,7 +26696,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte med angivna parametrar.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26723,7 +26723,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>&lt;%1&gt; element hittades med angivna parametrar.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26750,7 +26750,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En tabell med två rader måste skickas.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26777,7 +26777,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklient med PID &lt;%1&gt; mottagen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26804,7 +26804,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sökväg till tokenfil har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26831,7 +26831,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stoppa scenariokörning</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26858,7 +26858,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stopp</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26885,7 +26885,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stoppa lektionen</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26912,7 +26912,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Lektionen är avslutad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26939,7 +26939,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenariokörning: &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26966,7 +26966,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Lektionskörning: &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -26993,7 +26993,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vanessa Automation Editor saknas.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27020,7 +27020,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte läsa data från filen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27047,7 +27047,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Internetanslutning är inte tillgänglig.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27074,7 +27074,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte fastställa versionsnumret för Vanessa Automation från raden &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27101,7 +27101,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Röstcache har installerats.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27128,7 +27128,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Installation av röstcache misslyckades. Utför åtgärden manuellt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27155,7 +27155,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Skapa fil…</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27182,7 +27182,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Öppna fil…</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27209,7 +27209,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Öppna mapp…</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27236,7 +27236,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Öppna lektionslista</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27263,7 +27263,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Starta</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27290,7 +27290,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Senaste</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27317,7 +27317,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Utbildning</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27344,7 +27344,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Verktyg för att skapa scenariotester</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27371,7 +27371,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välkommen!</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27398,7 +27398,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vi har tester!</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27425,7 +27425,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Uttrycket &lt;%2&gt; förväntades bli sant inom &lt;%1&gt; sekunder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27452,7 +27452,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Är du säker? Denna åtgärd kan inte ångras.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27479,7 +27479,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Återställ inställningar</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27506,7 +27506,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välj inställningsfil</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27533,7 +27533,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Formuläret &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27560,7 +27560,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att formuläret &lt;%2&gt; skulle stängas.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27587,7 +27587,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningarna för att generera Allure-rapport har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27614,7 +27614,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte verifiera Allure-installationen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27641,7 +27641,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stoppa inspelning av åtgärder</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27668,7 +27668,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Utbildningsläget fungerar inte i Single-leveransen. Installera den fullständiga versionen av Vanessa Automation.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27695,7 +27695,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att bilden &lt;%2&gt; skulle visas.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27722,7 +27722,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte i gruppen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27749,7 +27749,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte med Vanessa Automation-formulärelementnamn. PID &lt;%1&gt;, namn &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27776,7 +27776,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte. PID &lt;%1&gt;, rubrik/ID &lt;%2&gt;, typ &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27803,7 +27803,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönsterrubriken för Vanessa Automation hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27830,7 +27830,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Algoritmen startar efter att scenariokörningen är klar.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27857,7 +27857,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktivt element hittades inte under markören.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27884,7 +27884,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade aktivt element med namnet &lt;%1&gt;. Typ &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27911,7 +27911,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tips</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27938,7 +27938,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det rekommenderas att aktivera komponenten VanessaExt</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27965,7 +27965,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För att få detaljerad hjälp om formulärelementet, håll markören över det och tryck alt+H. Klicka på hyperlänken för demonstration</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -27992,7 +27992,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För att få detaljerad hjälp om formulärelementet, håll markören över det och tryck alt+H. Komponenten VanessaExt måste vara aktiverad</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28019,7 +28019,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vanessa Automation-formulärelement hittades inte för &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28046,7 +28046,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Namn: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28073,7 +28073,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Rubrik: %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28100,7 +28100,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Verktygstips: %3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28127,7 +28127,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Utökat verktygstips: %4</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28154,7 +28154,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hjälp om</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28181,7 +28181,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Formulärelementdata:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28208,7 +28208,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Interaktiva hjälplektioner för formulärelementet hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28235,7 +28235,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Interaktiva hjälplektioner där formulärelementet förekommer</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28262,7 +28262,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Synkrona anrop måste vara tillåtna. Det räcker att starta 1C-sessionen utanför Designern.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28289,7 +28289,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Håll markören över formulärelementet och tryck alt+H.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28316,7 +28316,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fil nr %1 av %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28343,7 +28343,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inbäddat formulär nr %1 av %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28370,7 +28370,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade &lt;%1&gt; processer för att ta skärmbilder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28397,7 +28397,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade &lt;%1&gt; fönster för att ta skärmbilder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28424,7 +28424,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Texten &lt;%1&gt; hittades inte i redigeraren.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28451,7 +28451,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Öppna vallistan &lt;%1&gt; innehåller dublettvärden: %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28478,7 +28478,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningen &quot;ToolsCatalog&quot; är tom.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28505,7 +28505,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Verktygskatalogen &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28532,7 +28532,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte ladda ner lektioner. Utför åtgärden manuellt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28559,7 +28559,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Lektionerna har installerats.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28586,7 +28586,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det rekommenderas att spara inställningarna</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28613,7 +28613,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Cellen med texten &lt;%1&gt; hittades inte i kalkylbladsdokumentet &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28640,7 +28640,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Texten &lt;%1&gt; hittades inte i redigeraren. Aktuell text: %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28667,7 +28667,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklienten startades på rätt port.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28694,7 +28694,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Namn på Onboarding-tillstånd har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28721,7 +28721,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktuellt Onboarding-fönster har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28748,7 +28748,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktivera komponenten &lt;VanessaExt&gt; för att kopiera information till urklipp. Vill du aktivera komponenten?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28775,7 +28775,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Beskrivning av parametrar som kan skickas i filen VAParams.json, som används vid start av Vanessa Automation från kommandoraden.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28802,7 +28802,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Globala variabler</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28829,7 +28829,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Speciella</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28856,7 +28856,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En array av nyckel- och värdeobjekt. Denna array laddas in i globala variabler och blir tillgänglig vid körning av scenariot i objektet ContextSaved.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28883,7 +28883,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ingen procedur eller funktion hittades för att utföra steget: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28910,7 +28910,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalogen för Allure-rapport har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28937,7 +28937,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att fältet &lt;%2&gt; skulle försvinna. Men detta formulärelement hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28964,7 +28964,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att fältet &lt;%2&gt; skulle försvinna. Aktuell synlighet=%3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -28991,7 +28991,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalogen för temporära filer har inte angetts i inställningarna.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29018,7 +29018,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Processen &lt;%1&gt; förväntades existera.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29045,7 +29045,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Processen &lt;%1&gt; förväntades inte existera.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29072,7 +29072,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Skapa snabbt en temporär feature-fil…</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29099,7 +29099,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Redigerarinitialisering misslyckades: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29126,7 +29126,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inget element av typen &lt;%1&gt; hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29153,7 +29153,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fler än ett element av typen &lt;%1&gt; hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29180,7 +29180,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För bekvämare och effektivare arbete rekommenderas det att aktivera den externa komponenten</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29207,7 +29207,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktivera?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29234,7 +29234,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välkommen till assistenten för första start. Klicka här för detaljerad hjälp om Vanessa Automation.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29261,7 +29261,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Här finns de huvudsakliga verktygen i Vanessa Automation.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29288,7 +29288,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Här finns de huvudsakliga inställningarna för Vanessa Automation-redigeraren.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29315,7 +29315,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Efter första starten rekommenderas det att spara inställningarna.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29342,7 +29342,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För att få detaljerad hjälp om ett formulärelement, håll markören över det och tryck alt+H.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29369,7 +29369,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Formulärelementet &lt;%1&gt; hittades inte</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29396,7 +29396,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Variabeltyp &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29423,7 +29423,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Status för det föregående scenariot &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29450,7 +29450,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>I fönstret &lt;%1&gt; kunde inte elementet &lt;%2&gt; klicka på hyperlänken &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29477,7 +29477,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Komponentversion</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29504,7 +29504,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Redigerarversion</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29531,7 +29531,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tillbaka</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29558,7 +29558,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Framåt</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29585,7 +29585,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Slutför</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29612,7 +29612,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte. PID &lt;%1&gt;, verktygstips &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29639,7 +29639,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>UI Automation-element hittades inte. PID &lt;%1&gt;, typ &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29666,7 +29666,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade &lt;%1&gt; knappar med rubriken &lt;%2&gt;. Försök att söka efter formulärelementet med namn.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29693,7 +29693,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Möjlig mallsträng &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29720,7 +29720,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det förväntades att det aktuella formuläret har modifieringsmärkning.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29747,7 +29747,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det förväntades att det aktuella formuläret inte har modifieringsmärkning.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29774,7 +29774,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det förväntades att det aktuella formuläret har skrivskyddsmärkning.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29801,7 +29801,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det förväntades att det aktuella formuläret inte har skrivskyddsmärkning.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29828,7 +29828,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ange nytt kolumnnamn</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29855,7 +29855,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Startkommandot för webbläsaren har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29882,7 +29882,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Processen hittades inte med fönsterrubriken &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29909,7 +29909,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>&lt;%2&gt; filer &lt;%3&gt; hittades i katalogen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29936,7 +29936,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fliken med filen &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29963,7 +29963,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ogiltigt värde i den första kolumnen i tabellen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -29990,7 +29990,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenariokörningen har stoppats.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30017,7 +30017,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Knappen &lt;%1&gt; finns, men den förväntades inte finnas.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30044,7 +30044,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Webbläsarfliken med rubriken &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30071,7 +30071,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det förväntades att den aktuella raden i tabellen &lt;%1&gt; är expanderad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30098,7 +30098,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det förväntades att den aktuella raden i tabellen &lt;%1&gt; är komprimerad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30125,7 +30125,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kalkylbladsdokumentet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30152,7 +30152,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det bör finnas 2 eller fler rader i ett kalkylbladsdokument.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30179,7 +30179,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade &lt;%1&gt; sekunder på att formuläret &lt;%2&gt; skulle öppnas.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30206,7 +30206,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inga data hittades för fönstret &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30233,7 +30233,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Modalt dialogfönster med information om objektet hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30260,7 +30260,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklientprofilen &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30287,7 +30287,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklientprofilen &lt;%1&gt; hittades inte för stängning.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30314,7 +30314,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklientprofilen &lt;%1&gt; hittades inte trots att den borde vara aktiv.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30341,7 +30341,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Strängen &lt;%1&gt; innehåller ryska bokstäver.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30368,7 +30368,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>NameEn: %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30395,7 +30395,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Titel: %3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30422,7 +30422,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ledtråd: %4</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30449,7 +30449,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Utökad ledtråd: %5</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30476,7 +30476,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Steget &lt;%1&gt; misslyckades i Försök/Undantag-sektionen. Trädrad nr %2. Feature-filrad nr %3.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30503,7 +30503,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Utbildningsläge</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30530,7 +30530,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Variabelnamn</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30557,7 +30557,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Värde</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30584,7 +30584,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Knapp/kommando med rubriken &lt;%1&gt; hittades inte eller fler än en hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30611,7 +30611,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sektionspanel &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30638,7 +30638,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Formulärelement med samma rubrik hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30665,7 +30665,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>TestClientName</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30692,7 +30692,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>TestClientSynonym</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30719,7 +30719,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>AdditionalParametersConnections</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30746,7 +30746,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte klicka på funktionspanelkommandot &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30773,7 +30773,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Webbläsarfliken &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30800,7 +30800,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Texten &lt;%1&gt; hittades inte i webbläsarfliken.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30827,7 +30827,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>minuter</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30854,7 +30854,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>(*.mxl)|*.mxl</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30881,7 +30881,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>%1 %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30908,7 +30908,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>%1 = %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30935,7 +30935,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>%1. %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30962,7 +30962,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>%1.%2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -30989,7 +30989,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Failed: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31016,7 +31016,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ffmpeg - OK</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31043,7 +31043,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ImageMagic - OK</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31070,7 +31070,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>oscript - OK</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31097,7 +31097,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Pending: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31124,7 +31124,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Sleep:%1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31151,7 +31151,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>VLC 2.1.5 - OK</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31178,7 +31178,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktiverar fönstret med koordinater: %1%2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31205,7 +31205,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Webbläsare</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31232,7 +31232,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Strängen &lt;%2&gt; hittades i formulärelementet %1 värde. Aktuellt fältvärde är &lt;%3&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31259,7 +31259,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte klicka på knappen &lt;%3&gt; för elementet &lt;%2&gt; i fönstret &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31286,7 +31286,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kolumnen &lt;%2&gt; hittades inte i tabellen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31313,7 +31313,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Dokumenttyp måste anges</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31340,7 +31340,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Metadatatyp måste anges</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31367,7 +31367,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalogtyp måste anges</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31394,7 +31394,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ScriptTimeline</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31421,7 +31421,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välj inställningsfilen för scenariogeneratorn.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31448,7 +31448,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Anropar proceduren &quot;&quot;ViewValue&quot;&quot;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31475,7 +31475,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kör kod: %1.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31502,7 +31502,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Datum1 måste anges</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31529,7 +31529,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Datum2 måste anges</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31556,7 +31556,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>AddTestClientFormState: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31583,7 +31583,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>antingen ackumulationsregister eller bokföringsregister måste skickas</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31610,7 +31610,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Om tabelldelen inte har angetts ska filterstrukturen för tabelldelen inte heller anges</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31637,7 +31637,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Snippets laddades från cache</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31664,7 +31664,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ladda in features? &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31691,7 +31691,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Värdet för den globala variabeln &lt;%1&gt; ändrades från &lt;%2&gt; till &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31718,7 +31718,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Värdet för variabeln &lt;%1&gt; ändrades från &lt;%2&gt; till &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31745,7 +31745,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Bild: %1 skiljer sig</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31772,7 +31772,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalogen &lt;%1&gt; kommer att rensas. Fortsätta?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31799,7 +31799,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>HTMLInstructionsDirectory har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31826,7 +31826,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>MarkdownInstructionsDirectory har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31853,7 +31853,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ScreenshotsDirectory har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31880,7 +31880,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Knappen med rubriken &lt;%1&gt; och namnet &lt;%2&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31907,7 +31907,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ffmpeg-kommandot för att koda filen med feature-rubriken till mp4 kördes inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31934,7 +31934,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ffmpeg-kommandot för att koda den slutliga filen till mp4 kördes inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31961,7 +31961,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ffmpeg-kommandot för att sammanfoga filen med feature-rubriken med huvudvideon kördes inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -31988,7 +31988,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ffmpeg-kommandot för att sammanfoga den slutliga filen med huvudvideon kördes inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32015,7 +32015,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Mobil enhet hittades</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32042,7 +32042,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>%1 fel hittades:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32069,7 +32069,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade ett fönster med feltexten: %1.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32096,7 +32096,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningar (*.json)|*.json</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32123,7 +32123,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>VA-inställningar (*.feature)|*.feature</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32150,7 +32150,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>VA-inställningar (*.json)|*.json</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32177,7 +32177,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Starta beteendeinspelning</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32204,7 +32204,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta värdet från startkommandoraden: %1.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32231,7 +32231,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta koordinaterna för fönstrets stängningsknapp &lt;%1&gt; i webbläsaren: %2.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32258,7 +32258,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte stänga fönstret för regionala inställningar</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32285,7 +32285,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningen &quot;ToolsDirectory&quot; har inte fyllts i.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32312,7 +32312,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>testdata har inte fyllts i. Kanske är datamallen tom.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32339,7 +32339,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklient att ansluta till hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32366,7 +32366,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ObjectManager hittades inte</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32393,7 +32393,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Strängöversättning hittades inte:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32420,7 +32420,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen hittades inte: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32447,7 +32447,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Elementet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32474,7 +32474,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Formulärelementet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32501,7 +32501,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Den aktiva kolumnen i tabellen &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32528,7 +32528,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Initialtillståndet hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32555,7 +32555,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Anslutna enheter hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32582,7 +32582,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Onboarding-tillståndet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32609,7 +32609,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ansluten enhet upptäcktes inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32636,7 +32636,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>TestClient är inte ansluten.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32663,7 +32663,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte köra koden på testklientens sida.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32690,7 +32690,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte starta SikuliX-servern.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32717,7 +32717,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte starta mätningen. Anslutningsfel till felsökningsservern. Mätningen har stoppats</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32744,7 +32744,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fil för texten &lt;%1&gt; hittades inte i cachen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32771,7 +32771,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte avgöra det aktiva TestClient-fönstret.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32798,7 +32798,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte avgöra det aktiva fältet i tabellen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32825,7 +32825,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte dra och släppa från &lt;%1&gt; till &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32852,7 +32852,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte högerklicka på bilden &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32879,7 +32879,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte konvertera filen &quot;&quot;ogg&quot;&quot; till &quot;&quot;mp3&quot;&quot;. Kommando:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32906,7 +32906,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte spara strängen &lt;%1&gt; till variabeln &lt;%2&gt;. Felbeskrivning - &lt;%3&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32933,7 +32933,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte radera filen %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32960,7 +32960,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte fastställa tangentkoden &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -32987,7 +32987,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte fastställa musens rotationsriktning &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33014,7 +33014,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte läsa JSON-inställningsfilen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33041,7 +33041,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte installera serviceverktyg. Utför åtgärden manuellt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33068,7 +33068,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ytterligare värdetyp har inte angetts</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33095,7 +33095,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Övergångsriktningen är felaktigt angiven i tabellen: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33122,7 +33122,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Värdet för mushjulets rotationsriktningsparameter är felaktigt: &lt;%1&gt;. Möjliga värden: Upp eller Ner.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33149,7 +33149,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Okänd parametertyp i GetFileSystemObjectsParametersAsyncronous: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33176,7 +33176,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Okänt arbetsalternativ - metoden &lt;AddObjectToTemplate&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33203,7 +33203,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Aktivera bildsökning med den externa komponenten VanessaExt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33230,7 +33230,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Allure-installation krävs.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33257,7 +33257,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ange parametrar i VAParams.json:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33284,7 +33284,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade fler än 1 parameter L</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33311,7 +33311,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningar hittades i konfigurationsträdet. Rensa?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33338,7 +33338,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att fältet &lt;%2&gt; skulle bli otillgängligt. AktuellTillgänglighet= %3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33365,7 +33365,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att scenarier skulle köras i Vanessa Automation-testfönstret.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33392,7 +33392,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%1&gt; sekunder på att fliken med ID &lt;%2&gt; skulle ändras och försvinna.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33419,7 +33419,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade samma antal bilder: &lt;%1&gt;, men fick &lt;%2&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33446,7 +33446,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade i &lt;%2&gt; sekunder på att det aktuella fältet i tabellen &lt;%1&gt; inte ska vara ifyllt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33473,7 +33473,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att bilderna skulle vara lika, men de skiljer sig</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33500,7 +33500,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att det aktiva fönstret skulle vara ett fönster från listan &lt;%1&gt;, men hittade &lt;%2&gt;. Timeout för fönstersökning: %3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33527,7 +33527,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade elementet &lt;%1&gt; i sektionspanelen, men elementet &lt;%2&gt; hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33554,7 +33554,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att sektionspanelen inte skulle innehålla följande element: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33581,7 +33581,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Frasuppläsning</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33608,7 +33608,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vanessa Automation Editor saknas</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33635,7 +33635,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel vid förberedelse av stegkörning: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33662,7 +33662,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>WebSocket-anslutningsfel.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33689,7 +33689,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Anslutningsfel till felsökningsservern. Mätningarna har stoppats.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33716,7 +33716,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel vid skapande av mp3 efter feature-katalog.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33743,7 +33743,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel. Troligtvis hittades inte adb-programmet. Installera det eller ange sökvägen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33770,7 +33770,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel. Okänt värde för parametern CurrentOperationValue = %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33797,7 +33797,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Variabeln &lt;%1&gt; har redan deklarerats. Överskrivning är inaktiverad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33824,7 +33824,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Undermeny med rubriken &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33851,7 +33851,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Undermenyn med namnet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33878,7 +33878,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>FeatureFullPath</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33905,7 +33905,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ett fel uppstod vid körning av koden: &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33932,7 +33932,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Arbete med nycklar vid skapande av användare stöds inte ännu</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33959,7 +33959,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Serviceverktyg</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -33986,7 +33986,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Serviceverktyg är installerade.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34013,7 +34013,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ladda ner och installera serviceverktyg för SikuliX-steg?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34040,7 +34040,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Spara inställningar</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34067,7 +34067,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenarierna har laddats in i scenariostartträdet</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34094,7 +34094,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tabellen &lt;%1&gt; innehöll inte rader från den överförda tabellen inom &lt;%2&gt; sekunder. %3</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34121,7 +34121,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tabell &lt;%1&gt;. Rad nr &lt;%2&gt;. Kolumn &lt;%3&gt;. Kunde inte hämta värdet från referensen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34148,7 +34148,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En tabell i minnet med namnet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34175,7 +34175,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenariotexten överensstämmer inte med referensscenariots text.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34202,7 +34202,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tekniska data:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34229,7 +34229,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Typ</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34256,7 +34256,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Metadatatyp måste anges</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34283,7 +34283,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>PlatformType</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34310,7 +34310,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tabellen &lt;%1&gt; förväntades ha kolumnen &lt;%2&gt; aktiv, inte &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34337,7 +34337,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Föråldrat och stöds inte längre: https://github.com/xDrivenDevelopment/xUnitFor1C/issues/332</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34364,7 +34364,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen &lt;%1&gt; är inte lika med filen &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34391,7 +34391,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>EPF-filen skapades inte. Kunde inte skapa en temporär databaskatalog.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34418,7 +34418,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen HTMLInstructionUploadCatalog: %1 finns inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34445,7 +34445,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen MarkdownInstructionUploadCatalog: %1 finns inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34472,7 +34472,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Mallfil hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34499,7 +34499,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>VA-inställningsfil</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34526,7 +34526,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Uppdatera</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34553,7 +34553,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Uppdatera värdet i scenariot till den aktuella tabellraden hos testklienten &lt;%1&gt;?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34580,7 +34580,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Skapa snabbt en temporär feature-fil...</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34607,7 +34607,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>I det engelska gränssnittet bör formulärelement inte innehålla ryska bokstäver.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34634,7 +34634,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Gherkin-tabell hittades inte i scenariotexten.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34661,7 +34661,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kolumnen &lt;%1&gt; hittades inte i det aktuella tabellvärdet.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34688,7 +34688,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Denna lektion har ändrats sedan versionen &lt;%1&gt;. För att lektionen ska fungera måste talsyntes vara aktiverad.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34715,7 +34715,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Intervall %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34742,7 +34742,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det finns ingen steguppdatering för denna typ av fel.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34769,7 +34769,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ersätter värdet &lt;%1&gt; i steget med &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34796,7 +34796,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>&lt;%2&gt; rader mottogs från tabellen &lt;%1&gt; men en rad förväntades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34823,7 +34823,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Antalet tabellrader har ändrats. Vid ersättning kommer *-tecknen att tas bort. Fortsätta?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34850,7 +34850,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tabellens storlek har ändrats. Vid ersättning kommer *-tecknen att tas bort. Fortsätta?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34877,7 +34877,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Knappnamn:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34904,7 +34904,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Namn:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34931,7 +34931,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade problem:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34958,7 +34958,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte uppdatera stegparametrar.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -34985,7 +34985,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Du kan inte uppdatera värdet, eftersom det inte finns några rader i tabellen i scenariot.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35012,7 +35012,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Du kan inte uppdatera värdet, eftersom Gherkin-tabellen ska ha 2 rader.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35039,7 +35039,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntar på att processen med pid &lt;%1&gt; till &lt;%2&gt; ska stängas.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35066,7 +35066,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Öppna feature-fil...</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35093,7 +35093,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tvångsavslutning av testklientprocessen med pid &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35120,7 +35120,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Processen med pid &lt;%1&gt; finns fortfarande.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35147,7 +35147,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Processen med pid &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35174,7 +35174,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Skapa feature-fil...</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35201,7 +35201,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tempo %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35228,7 +35228,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen &lt;%1&gt; kommer att skrivas över. Är du säker?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35255,7 +35255,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen &lt;%1&gt; kommer att skrivas över. Även värden som innehåller *-tecken kommer att ersättas. Är du säker?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35282,7 +35282,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen &lt;%1&gt; har skrivits över.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35309,7 +35309,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen &lt;%1&gt; skrevs inte över.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35336,7 +35336,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ett ogiltigt värde &lt;%1&gt; skickades i den tredje kolumnen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35363,7 +35363,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kör scenariot &lt;%1&gt; igen. Försök nr %2</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35390,7 +35390,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För formulärelementet &lt;%1&gt; är det aktuella värdet &lt;%2&gt; och &lt;%3&gt; förväntades</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35417,7 +35417,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Om sessionen startades från Designern rekommenderas det att starta testhanterarens session utanför Designern. Då fungerar synkrona anrop oavsett konfigurationsinställningar.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35444,7 +35444,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Antalet tabellrader har ändrats. Vid ersättning kommer *- och $-tecknen att tas bort. Fortsätta?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35471,7 +35471,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tabellens storlek har ändrats. Vid ersättning kommer *- och $-tecknen att tas bort. Fortsätta?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35498,7 +35498,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Namn</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35525,7 +35525,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenarionamn:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35552,7 +35552,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>HowToSearch</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35579,7 +35579,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Hittade instanser av serveranrop i händelsehanterare:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35606,7 +35606,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningarna förbjuder anslutning av mer än en testklient samtidigt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35633,7 +35633,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte aktivera fönstret med PID &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35660,7 +35660,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hitta formulärelementet &lt;%1&gt; med hjälp av UI Automation.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35687,7 +35687,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte radera filen &lt;%1&gt;. Troligtvis används filen av ett annat program. Filnamnet har ändrats.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35714,7 +35714,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vanessa Automation-inställningsvärdet har inte angetts: &lt;ToolsDirectory&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35741,7 +35741,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förbud mot synkrona anrop upptäcktes.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35768,7 +35768,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kalkylbladsdokumentet &lt;%1&gt; förväntades vara fyllt med data.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35795,7 +35795,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fel vid läsning av json.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35822,7 +35822,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklienten är ansluten. PID &lt;%1&gt;. Port &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35849,7 +35849,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Se detaljer här: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35876,7 +35876,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ByTitle</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35903,7 +35903,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>ByName</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35930,7 +35930,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det rekommenderas att byta till ett läge där synkrona anrop är tillåtna, eftersom arbetet med filsystemet går snabbare i det läget.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35957,7 +35957,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Flaggan &lt;Stoppa vid fel&gt; är satt. Följande scenarier/steg har avbrutits.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -35984,7 +35984,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen &lt;%1&gt; kommer att skrivas över. Även värden som innehåller *- och $-tecken kommer att ersättas. Är du säker?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36011,7 +36011,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För att validera serveranrop i händelsehanterare måste du tillåta synkrona anrop.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36038,7 +36038,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen &lt;%1&gt; hittades inte i projektkatalogen eller i feature-katalogen.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36065,7 +36065,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det finns inga filer i cachen för tillägget.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36092,7 +36092,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Generering av tester slutförd:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36119,7 +36119,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalog har inte angetts</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36146,7 +36146,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Mp3-cache för uppdatering måste anges i fältet FeatureKatalog.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36173,7 +36173,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Startgenerering av tester:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36200,7 +36200,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fullständig sökväg till cachefilen hittades inte: &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36227,7 +36227,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalog för utdatafiler har inte angetts! Röktester kommer inte att genereras.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36254,7 +36254,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det är nödvändigt att aktivera den externa komponenten VanessaExt och bildsökning med komponenten.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36281,7 +36281,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Väntade &lt;%1&gt; sekunder på att filen %2 skulle visas</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36308,7 +36308,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fältet &lt;%1&gt; i kalkylbladsdokumentet hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36335,7 +36335,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inga scenarier hittades att köra. Om starttaggar angavs, försök att ladda om .feature-filen</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36362,7 +36362,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kalkylbladsdokumentet &lt;%1&gt; hade visningstillståndet &lt;%3&gt; istället för det förväntade &lt;%2&gt; under &lt;%4&gt; sekunder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36389,7 +36389,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kalkylbladsdokumentet &lt;%1&gt; hade visningstillståndet &lt;%3&gt; istället för det förväntade &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36416,7 +36416,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Steget fungerar från och med plattformsversionen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36443,7 +36443,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Dokumentet &lt;%1&gt; bokfördes utan fel.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36470,7 +36470,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Dokumentet &lt;%1&gt; bokfördes utan fel.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36497,7 +36497,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta objektets tillstånd från navigeringslänken &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36524,7 +36524,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte bokföra dokumentet &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36551,7 +36551,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte avbokföra dokumentet &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36578,7 +36578,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte avbokföra dokument från det aktuella scenariot.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36605,7 +36605,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vid bokföring av dokumentet &lt;%1&gt; mottogs feltexten &lt;%2&gt;. Feltexten &lt;%3&gt; förväntades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36632,7 +36632,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vid avbokföring av dokumentet &lt;%1&gt; mottogs feltexten &lt;%2&gt;. Feltexten &lt;%3&gt; förväntades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36659,7 +36659,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ett fel uppstod vid generering av rapporten &lt;%1&gt; &lt;%2&gt;:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36686,7 +36686,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningarna har ändrats. Spara ändrade inställningar?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36713,7 +36713,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Välj csv-fil</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36740,7 +36740,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ladda inställningar från vald fil?</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36767,7 +36767,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenarioinställningarna laddas. Vänta...</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36794,7 +36794,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Scenariokonfigurationsfilen hittades inte!</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36821,7 +36821,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Utdatakatalog har inte angetts! Röktester kommer inte att genereras.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36848,7 +36848,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För många parametrar skickades till steget.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36875,7 +36875,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Du angav ett felaktigt gränsintervall. NedreGräns är större än ÖvreGräns.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36902,7 +36902,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Generering av röktester slutförd (%1 sek.).</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36929,7 +36929,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Denna funktion fungerar bara i plattform 8.3.25 och högre.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36956,7 +36956,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kan inte fastställa värdet för tabellkolumnen &lt;%1&gt;. Tabellen kommer inte att ordnas efter kolumner som de är placerade i testklientens tabell.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -36983,7 +36983,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kan inte fastställa ordningen för kolumnen &lt;%1&gt;. Tabellen kommer inte att ordnas efter kolumner som de är placerade i testklientens tabell.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37010,7 +37010,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Startar generering av röktester.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37037,7 +37037,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fellogg: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37064,7 +37064,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Inställningen &lt;%1&gt; är bara tillgänglig i Windows.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37091,7 +37091,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kan inte hämta presentationen av den öppnade vallistan kopplad till formuläret.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37118,7 +37118,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kan inte hämta vallistans presentation.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37145,7 +37145,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Taggen &lt;%1&gt; för att hämta värdet hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37172,7 +37172,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kan inte rensa kalkylbladsdokumentet &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37199,7 +37199,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Plattformsversionerna för testhanteraren och testklienten stämmer inte överens. Testklienten startades på plattformsversion &lt;%1&gt; och testhanteraren på &lt;%2&gt;. Anslutningen kan inte upprättas med olika plattformsversioner.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37226,7 +37226,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kan inte radera tillägget med namnet &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37253,7 +37253,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Katalog för utdatafiler har inte angetts!</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37280,7 +37280,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Okänd åtgärdstyp &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37307,7 +37307,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kan inte göra ersättningen, eftersom flera &lt;%1&gt; formulärelement hittades med strängen &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37334,7 +37334,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ett försök upptäcktes att starta scenariokörning från scenario nr &lt;%1&gt;, men bara &lt;%2&gt; scenarier hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37361,7 +37361,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Flera kolumner med samma rubrik &lt;%1&gt; hittades. Tabellen kommer inte att ordnas efter kolumner som de är placerade i testklientens tabell.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37388,7 +37388,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En avvikelse hittades mellan testklientens tabell och mallen. Strängar hittades inte: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37415,7 +37415,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att fältet &lt;%1&gt; inte skulle vara lika med variabeln &lt;%2&gt;. Variabelns värde är &lt;%3&gt;. Fältvärde &lt;%4&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37442,7 +37442,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att fältet med rubriken &lt;%1&gt; skulle vara tomt, men det är inte tomt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37469,7 +37469,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att kalkylbladsdokumentet &lt;%1&gt; skulle ha texten i cellen med adressen &lt;%2&gt; inom områdets gränser.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37496,7 +37496,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att kalkylbladsdokumentet &lt;%1&gt; skulle ha ett område (cell) med adressen &lt;%2&gt; inkluderat i det sammanslagna området.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37523,7 +37523,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att kalkylbladsdokumentet &lt;%1&gt; område (cell) med adressen &lt;%2&gt; inte skulle vara inkluderat i det sammanslagna området.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37550,7 +37550,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade under &lt;%1&gt; sekunder att det aktiva fönstret skulle vara fönstret med rubriken &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37577,7 +37577,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att det aktuella formuläret skulle vara redigerbart.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37604,7 +37604,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att det aktuella formuläret inte skulle vara redigerbart.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37631,7 +37631,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Den öppna vallistan kopplad till formuläret innehåller inte de förväntade värdena: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37658,7 +37658,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Den öppna vallistan kopplad till formuläret innehåller dublettvärden: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37685,7 +37685,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Den öppna vallistan kopplad till formuläret innehåller oväntade värden: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37712,7 +37712,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Den öppna vallistan kopplad till formuläret är inte lika med mallen. Skillnader: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37739,7 +37739,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filsökningsfel: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37766,7 +37766,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tillägget med namnet &lt;%1&gt; är redan installerat.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37793,7 +37793,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Strängen &lt;%1&gt; är felaktigt formaterad. Feature-sträng &lt;%2&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37820,7 +37820,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fältet &lt;%1&gt; rubrik förväntades vara &lt;%2&gt;, och det aktuella värdet är &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37847,7 +37847,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vallistan kopplad till formuläret förväntades ha %1 värden, och %2 värden mottogs.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37874,7 +37874,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Formulärelementet &lt;%1&gt; har den aktuella redigeringstexten &lt;%2&gt;, och &lt;%3&gt; förväntades under &lt;%4&gt; sekunder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37901,7 +37901,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Steget misslyckades i Försök/Undantag-sektionen: &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37928,7 +37928,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>2. Märklig parameter i HTML-instruktionsloggen: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37955,7 +37955,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Auktoriseringen till talsyntestjänsten lyckades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -37982,7 +37982,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Variabeln Str förväntades ha typen &lt;String&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38009,7 +38009,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En snabbkontroll av bakgrundsjobb utfördes.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38036,7 +38036,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>TestManagerData.PIDTestManager = %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38063,7 +38063,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Flera matchningar hittades för kolumnen &lt;%1&gt;; ersättning är inte möjlig: &lt;%2&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38090,7 +38090,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>För kolumnen &lt;%1&gt; hittades matchningen &lt;%2&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38117,7 +38117,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det hittades &lt;%2&gt; matchande rader för profilen &lt;%1&gt; i testklienttabellen, men det borde bara finnas en.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38144,7 +38144,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Det finns filer utan taggarna @uf-part1 och @uf-part2. En av dessa taggar krävs. Lista över problematiska filer:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38171,7 +38171,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kontrollen slutförd. Inga aktiva bakgrundsjobb hittades.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38198,7 +38198,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Systemdialogen &lt;%1&gt; stängdes. Scenariokörningen fortsatte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38225,7 +38225,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stänger kontrollen av bakgrundsjobb.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38252,7 +38252,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Stänger tilläggets fönster för bakgrundsjobkontroll</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38279,7 +38279,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fönstret &lt;%1&gt; stängdes</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38306,7 +38306,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>VAExtension-fönstret &lt;%1&gt; stängdes.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38333,7 +38333,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Byggstatusfil skriven: %1</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38360,7 +38360,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kör scenariot igen</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38387,7 +38387,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Arrayen i minnet med namnet &lt;%1&gt; hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38414,7 +38414,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Metoden RemoveLayoutIndents tar en parameter av typen SpreadsheetDocument, men den skickade parametern var av typen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38441,7 +38441,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En ny 1C-process hittades: &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38468,7 +38468,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta en lista över testklientens fönster.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38495,7 +38495,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Filen dit utdata från kommandot &lt;%1&gt; dirigerades hittades inte.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38522,7 +38522,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte inaktivera möjligheten att radera text i fält i det aktuella fönstret.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38549,7 +38549,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte exportera scenariostatus eftersom en katalog skickades, inte en fil.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38576,7 +38576,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte utföra ett steg i en sträng.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38603,7 +38603,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte beräkna tid för strängen &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38630,7 +38630,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte stänga fönstret &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38657,7 +38657,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta versionen av delsystemet &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38684,7 +38684,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte beräkna den aktuella versionen av testklientens gränssnitt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38711,7 +38711,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte läsa kommandoradsparametrar.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38738,7 +38738,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kunde inte hämta meddelanden för fönstret &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38765,7 +38765,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Lösenordet för auktorisering i 1C:s talsyntestjänst har inte angetts.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38792,7 +38792,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Okänd operation - metoden &lt;AddObjectToUpload&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38819,7 +38819,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Försöksnummer:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38846,7 +38846,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>AbnormalTestClientCompletionDetected</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38873,7 +38873,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Vi förväntade att den andra parametern skulle vara en parameterstruktur för metoden &lt;CreateDataByLayoutDocument&gt;, men vi fick ett annat objekt av typen &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38900,7 +38900,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fältet &lt;%2&gt; i tabellen &lt;%1&gt; förväntades vara ifyllt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38927,7 +38927,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fältet &lt;%2&gt; i tabellen &lt;%1&gt; förväntades vara tomt.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38954,7 +38954,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklienten förväntades köras i en klient-serverdatabas. Anslutningssträng: &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -38981,7 +38981,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Testklienten förväntades köras i en fildatabas. Anslutningssträng: &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39008,7 +39008,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Den aktuella tiden &lt;%1&gt; förväntades vara mellan &lt;%2&gt; och &lt;%3&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39035,7 +39035,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Elementet med rubriken &lt;%1&gt; förväntades försvinna inom &lt;%2&gt; sekunder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39062,7 +39062,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Elementet med namnet &lt;%1&gt; förväntades försvinna inom &lt;%2&gt; sekunder.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39089,7 +39089,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En modal dialog är öppen, så navigeringslänken &lt;%1&gt; kan inte öppnas</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39116,7 +39116,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Öppnar en process för att kontrollera slutförande av bakgrundsjobb</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39143,7 +39143,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tidsparametern &lt;%1&gt; måste skickas i formatet &quot;23:30:00&quot;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39170,7 +39170,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Fullständig kommandotext &lt;%1&gt;.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39197,7 +39197,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Mottog ett kalkylbladsdokument från binärdata &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39224,7 +39224,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Mottog binär layoutdata från filen &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39251,7 +39251,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Försöker hämta kalkylbladsdokumentet igen eftersom Odefinierad mottogs.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39278,7 +39278,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Representation av mallsträngen:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39305,7 +39305,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kontrollerar fönster med rubriken &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39332,7 +39332,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Rad nr %1 hittades inte i kalkylbladsdokumentet</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39359,7 +39359,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>En struktur som innehåller nyckel- och värdepar. Denna struktur laddas in i globala variabler, och dessa variabler blir tillgängliga vid körning av scenariot i objektet ContextPersisted.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39386,7 +39386,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Tabellen &lt;%1&gt; är tom</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39413,7 +39413,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Kalkylbladsdokumentet har sparats till en temporär fil &lt;%1&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39440,7 +39440,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Text i modalt fönster:</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39467,7 +39467,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Ett tomt lösenord har angetts för auktorisering i 1C:s talsyntestjänst</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39494,7 +39494,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Feature-språket matchar standardspråkinställningen &lt;%1&gt;. Översättning är inte möjlig.</v8:content>
 						</v8:item>
 					</tl>
 				</c>
@@ -39521,7 +39521,7 @@
 					<tl>
 						<v8:item>
 							<v8:lang>ru</v8:lang>
-							<v8:content>Translation not found</v8:content>
+							<v8:content>Förväntade att cellen &lt;%1&gt; skulle vara ifylld. Fönster &lt;%2&gt;</v8:content>
 						</v8:item>
 					</tl>
 				</c>


### PR DESCRIPTION
  ## Summary
  - Added comprehensive Swedish (sv) translations across all localization layers
  - All 19 forms: 2,279 UI elements translated (100% coverage of English entries)
  - User messages (locales/Messages): 1,461 entries translated (100% coverage)
  - Attribute synonyms in VanessaAutomation.xml: 311 entries translated (100% coverage)

  ## Details
  - Translations are based on existing English translations
  - Product names, technical identifiers and placeholders are preserved
  - Rich text formatting tags and URLs are kept intact
  - XML validity verified for all modified files
  - EPF compilation tested successfully

  ## Files changed
  - `VanessaAutomation.xml` — attribute/command synonyms
  - `VanessaAutomation/Forms/*/Ext/Form.xml` — 19 form files
  - `locales/Messages/Templates/sv/Ext/Template.xml` — user messages

  ## Test plan
  - [ ] Open the data processor in 1C:Enterprise with Swedish locale and verify UI labels
  - [ ] Check that Messages localization works correctly at runtime
  - [ ] Verify that attribute synonyms display properly on the Settings tab