### PR TITLE
Обновлен GitHub Actions versions (checkout, setup-python, gh-pages)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,13 +14,12 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
-        architecture: 'x64'
 
     - name: Install dependencies
       run: |
@@ -72,8 +71,8 @@ jobs:
         cp -R temp/site/. public/dev
     
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v2.5.0
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./public
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        publish_branch: gh-pages
+        publish_dir: ./public

--- a/.github/workflows/grammar.yml
+++ b/.github/workflows/grammar.yml
@@ -15,10 +15,11 @@ jobs:
   CheckTextsOnMainForm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
-        #cache: 'pip'
+        cache: 'pip'
+        cache-dependency-path: tools/python/grammar/requirements.txt
     - run: pip install -r tools/python/grammar/requirements.txt
     - run: python tools/python/grammar/check.py


### PR DESCRIPTION
  ## Что
                                                                                                                                                         
  Обновление версий actions в `gh-pages.yml` и `grammar.yml`:
                                                                                                                                                         
  | Action | Было | Стало |
  |---|---|---|                                                                                                                                          
  | `actions/checkout` | v1 / v2 | **v6** |                 
  | `actions/setup-python` | v1 / v2 | **v6** |
  | `peaceiris/actions-gh-pages` | v2.5.0 | **v4** |
                                                                                                                                                         
  `main.yml` уже на `actions/checkout@v6` — теперь все три workflow консистентны.
  
  ## Попутно                                                                                                                                             
                                                            
  - В `grammar.yml` включён `cache: 'pip'` с `cache-dependency-path: tools/python/grammar/requirements.txt`.                                             
  - В `gh-pages.yml` удалён устаревший `architecture: 'x64'` (default в v5+, эмитит warning).
  - Для `peaceiris/actions-gh-pages@v4` мигрирован синтаксис: `env:` → `with:`, параметры переименованы (`ACTIONS_DEPLOY_KEY` → `deploy_key`, `PUBLISH_BRANCH` → `publish_branch`, `PUBLISH_DIR` → `publish_dir`).                                                                                   
 