### PR TITLE
ci: обновление mkdocs-material 5.0.0 → 9.x + кеш pip для gh-pages 

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
         pip install --upgrade pip
         pip install -r requirements-docs.txt
     
-    - name: Dowload latest GitHub Pages
+    - name: Download latest GitHub Pages
       run: |
         wget https://github.com/${{ github.repository }}/archive/gh-pages.zip || true
         unzip gh-pages.zip || true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,11 +20,13 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
+        cache: pip
+        cache-dependency-path: requirements-docs.txt
 
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install mkdocs mkdocs-material==5.0.0 pygments-bsl
+        pip install -r requirements-docs.txt
     
     - name: Dowload latest GitHub Pages
       run: |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Vanessa Automation
 
-[![GitHub release](https://img.shields.io/github/release/Pr-Mex/vanessa-automation.svg)](docs/Changelog.md)
+[![GitHub release](https://img.shields.io/github/release/Pr-Mex/vanessa-automation.svg)](Changelog.md)
 [![Build Status](http://vanessa.bit-erp.ru/buildStatus/icon?job=VAFullCheck)](http://vanessa.bit-erp.ru/job/VAFullCheck/)
 [![GitHub Releases](https://img.shields.io/github/downloads/Pr-Mex/vanessa-automation/latest/total?style=flat-square)](https://github.com/Pr-Mex/vanessa-automation/releases)
 [![GitHub All Releases](https://img.shields.io/github/downloads/Pr-Mex/vanessa-automation/total?style=flat-square)](https://github.com/Pr-Mex/vanessa-automation/releases)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,9 @@ extra:
       link: https://t.me/VanessaAutomation
 markdown_extensions:
   - admonition
-  - codehilite
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
   - toc:
       permalink: true
 site_url: 'https://pr-mex.github.io/vanessa-automation'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,15 +1,16 @@
 site_name: Vanessa Automation
 theme:
   name: material
-  language: 'ru'
-  logo: 'assets/images/logo.png'
-  favicon: 'assets/images/logo.png'
+  language: ru
+  logo: assets/images/logo.png
+  favicon: assets/images/logo.png
   palette:
-    primary: 'white'
-    accent: 'red'
+    scheme: default
+    primary: white
+    accent: red
   features:
-    - tabs
-    - instant
+    - navigation.tabs
+    - navigation.instant
 plugins:
   - search:
       separator: '[\s\-\.]+'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,13 @@
 site_name: Vanessa Automation
 theme:
   name: material
-  language: ru
-  logo: assets/images/logo.png
-  favicon: assets/images/logo.png
+  language: 'ru'
+  logo: 'assets/images/logo.png'
+  favicon: 'assets/images/logo.png'
   palette:
-    scheme: default
-    primary: white
-    accent: red
+    scheme: 'default'
+    primary: 'white'
+    accent: 'red'
   features:
     - navigation.tabs
     - navigation.instant

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs<2
+mkdocs-material>=9.5,<10
+pygments-bsl

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
 mkdocs<2
 mkdocs-material~=9.7.6
+pymdown-extensions~=10.21.2
 pygments-bsl~=1.1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 mkdocs<2
-mkdocs-material>=9.5,<10
+mkdocs-material~=9.7.6
 pygments-bsl~=1.1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 mkdocs<2
 mkdocs-material>=9.5,<10
-pygments-bsl
+pygments-bsl~=1.1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-mkdocs<2
+mkdocs~=1.6.1
 mkdocs-material~=9.7.6
 pymdown-extensions~=10.21.2
 pygments-bsl~=1.1.0


### PR DESCRIPTION
  ## Что меняется                                                                                                                                        
                                                                                                                                                         
  - `mkdocs-material` поднимается с **5.0.0** (апрель 2020) до **>=9.5,<10**.                                                                            
  - Закреплён `mkdocs<2` — Material for MkDocs 9.x остаётся на платформе MkDocs 1.x и несовместим с предстоящим MkDocs 2.0 ([анонс squidfunk](https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/)).                                                                  
  - Зависимости docs вынесены в `requirements-docs.txt` для воспроизводимости.
  - Включён `cache: pip` для `gh-pages.yml` (#2535 закрыл то же для `grammar.yml`).   
  
  ## Контекст: Material в maintenance mode, MkDocs 2.0 и Zensical                                                                                        
                                                                                                                                                         
  Material for MkDocs с релиза 9.7.0 переведён в **maintenance mode**: команда squidfunk фокусируется на Zensical, для Material — только critical bug fixes и security updates минимум 12 месяцев (до ~ноября 2026):                                                                                  
                                                                                                                                                         
  - Material 9.x закреплён на `mkdocs<2` (версия 9.7.6, март 2026), новых фич не будет, только критические правки.                                       
  - MkDocs 2.0 — отдельный проект squidfunk: TOML, без плагинов, без override'ов темы, без миграции с 1.x, лицензия не объявлена, контрибьюции только от мейнтейнера. Material 9.x туда не переезжает.                                                                                                          
  - Zensical (https://github.com/zensical/zensical) — преемник от той же команды, MIT, alpha (v0.0.36, апрель 2026). Для production рано, лицензия и правила могут уточняться. 
  