### PR TITLE
ci: nelonoel/branch-name → github.ref_name в Sonar-workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    
-    - name: Вычисление имени ветки
-      uses: nelonoel/branch-name@v1.0.1
-    
+
     - name: Извлечение версии
       shell: bash
       run: echo "version=$(grep -oP '(?<=Версия \= \").[\d|.]*' ./VanessaAutomation/Ext/ObjectModule.bsl)" >> "$GITHUB_OUTPUT"
@@ -34,5 +31,5 @@ jobs:
       run: |
         sonar-scanner \
           -Dsonar.host.url=https://sonar.openbsl.ru \
-          -Dsonar.branch.name=${{ env.BRANCH_NAME }} \
+          -Dsonar.branch.name=${{ github.ref_name }} \
           -Dsonar.projectVersion=${{ steps.extract_version.outputs.version }}


### PR DESCRIPTION
  ## Что меняется
В `.github/workflows/main.yml` (Sonar-scan):                                                                                                                                                     
- Убран шаг «Вычисление имени ветки» с `nelonoel/branch-name@v1.0.1`.                                                                                  
- `${{ env.BRANCH_NAME }}` заменён на встроенный context `${{ github.ref_name }}`.