### PR TITLE
fix: устранён дубль 9 сценариев в MiddleCheck part1+part2 (баг парсера: теги «съедаются» блоком Переменные

### DIFF
--- a/features/Core/UIAutomation/КликиПоОсновнымЭлементамФормы.feature
+++ b/features/Core/UIAutomation/КликиПоОсновнымЭлементамФормы.feature
@@ -4,19 +4,6 @@
 #parent ua:
 @UA18_формировать_отчёт_Allure
 
-@IgnoreOn82Builds
-@IgnoreOnOFBuilds
-@IgnoreOnWeb
-
-@IgnoreOnUFSovm82Builds
-@IgnoreOn8312
-@IgnoreOn8313
-@IgnoreOn8314
-@IgnoreOn8315
-@IgnoreOn8316
-@IgnoreOn8317
-@IgnoreOn8318
-
 
 Переменные:
 	*__Таб_ВыделенияГруппой_01
@@ -25,6 +12,17 @@
 	| '_2'    | 'Реквизит1'    | ''     |
 
 @uf-part2
+@IgnoreOn82Builds
+@IgnoreOnOFBuilds
+@IgnoreOnWeb
+@IgnoreOnUFSovm82Builds
+@IgnoreOn8312
+@IgnoreOn8313
+@IgnoreOn8314
+@IgnoreOn8315
+@IgnoreOn8316
+@IgnoreOn8317
+@IgnoreOn8318
 Функционал: Проверка поиска основных элементов формы с помощью механизма UI Automation
 
 Как разработчик

--- a/features/Core/UIAutomation/КликиПоОсновнымЭлементамФормы.feature
+++ b/features/Core/UIAutomation/КликиПоОсновнымЭлементамФормы.feature
@@ -4,7 +4,6 @@
 #parent ua:
 @UA18_формировать_отчёт_Allure
 
-@uf-part2
 @IgnoreOn82Builds
 @IgnoreOnOFBuilds
 @IgnoreOnWeb
@@ -25,6 +24,7 @@
 	| '_1'    | 'Наименование' | 'Text' |
 	| '_2'    | 'Реквизит1'    | ''     |
 
+@uf-part2
 Функционал: Проверка поиска основных элементов формы с помощью механизма UI Automation
 
 Как разработчик

--- a/features/SikuliXServer/SikuliXServer.feature
+++ b/features/SikuliXServer/SikuliXServer.feature
@@ -22,6 +22,7 @@
 
 
 @tree
+@uf-part2
 
 
 Функциональность: Проверка работы SikuliX сервера (SikuliX server)

--- a/features/StepsRunner/ВыполнениеСценариевСЗакрытойФормой.feature
+++ b/features/StepsRunner/ВыполнениеСценариевСЗакрытойФормой.feature
@@ -9,7 +9,7 @@
 @IgnoreOnOFBuilds
 @IgnoreOnWeb
 
-
+@uf-part2
 Функционал: Выполнение сценариев с закрытой формой
 
 


### PR DESCRIPTION
 ## Что меняется 
Точечная правка 3 .feature-файлов partition-тегами `@uf-part2` для устранения дублирующего запуска 9 сценариев в MiddleCheck.

## Найденная причина — специфика парсера VanessaExt
Парсер `.feature`-файлов реализован в нативной C++ компоненте [lintest/VanessaExt](https://github.com/lintest/VanessaExt) (`gherkin.cpp`/`GherkinParser.cpp`). При парсинге теги накапливаются в `lexer.tagStack`, и при создании любого элемента верхнего уровня (`Feature`/`Scenario`/`Variables`/`Background`) **перемещаются (`std::move`) в этот элемент, очищая стек**:                                            
                                                            
  ```cpp
  GherkinElement(GherkinLexer& lexer, ...)
      : ... tags(std::move(lexer.tagStack))  // забирает ВСЕ накопленные теги                                                                            
                                                                                                                                                         
  Это означает: теги «принадлежат» первому элементу верхнего уровня после них. Если между блоком тегов и Функционал: стоит Переменные: — теги уезжают в  
  Variables-блок, и Функционал: получает пустой tags.                                                                                                    
                                                                                                                                                         
  Пример из КликиПоОсновнымЭлементамФормы.feature (до фикса):                                                                                            
   
  @uf-part2          ← в стеке                                                                                                                           
  @IgnoreOn82Builds  ← в стеке                              
  ... (12 тегов)                                                                                                                                         
                                                                                                                                                         
  Переменные:        ← std::move забирает все 12 тегов                                                                                                   
                     ← стек ПУСТОЙ!                                                                                                                      
    ...                                                                                                                                                  
                                                                                                                                                         
  Функционал: ...    ← получает [] 
  ```
  
## Эффект                                                                                                                                                
  - Удаляется 9 дублирующих запусков в каждом PR-check                                                                                                   
  - Экономия ~28 минут на каждый PR в Jenkins               
  - В файле 1 также восстановлена работа 11 других ignore-тегов (@IgnoreOn82Builds/OFBuilds/Web/UFSovm82Builds + per-version @IgnoreOn8312..8318) — они  были «съедены» парсером и не работали ни в одной сборке  

Создал так же https://github.com/lintest/VanessaExt/pull/93 с исправлениями