### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.9.108

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.101/AddIn.zip",
-"hash": "A8E15F5EA7B0A19BC9D0F790923F6F764E804CDD5E2BDADF01945C7F45D7FEC6",
-"version": "1.3.9.101"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.108/AddIn.zip",
+"hash": "A9B7DB3D4FDBB77E064782716BB8E9940CA4D0F59F280C76BA476C7D16C8F0D1",
+"version": "1.3.9.108"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Исправление: https://github.com/lintest/VanessaExt/pull/93 блок 'Переменные:' возвращает накопленные теги в стек