### PR TITLE
Обновление компоненты VanessaExt, версия 1.3.9.131

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -4,9 +4,9 @@
 "repo": "VanessaExt",
 "name": "AddIn.zip",
 "path": "../VanessaAutomation/Templates/WindowCaptureComponent/Ext/Template.bin",
-"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.108/AddIn.zip",
-"hash": "A9B7DB3D4FDBB77E064782716BB8E9940CA4D0F59F280C76BA476C7D16C8F0D1",
-"version": "1.3.9.108"
+"url": "https://github.com/lintest/VanessaExt/releases/download/1.3.9.131/AddIn.zip",
+"hash": "9CCAE6B95077F196641070E358A654047CCF4A4197722D8ACF8B2D82C4ACEA5A",
+"version": "1.3.9.131"
 },
 {
 "owner": "lintest",


### PR DESCRIPTION
Исправления:

https://github.com/lintest/VanessaExt/pull/99 fix: утечки GDI в VideoPainter (screen DC + HBITMAP)
https://github.com/lintest/VanessaExt/pull/98 fix: утечки thread handle во всех fire-and-forget CreateThread
https://github.com/lintest/VanessaExt/pull/97 fix: утечки std::string и thread handle в GherkinParser
https://github.com/lintest/VanessaExt/pull/96 fix: утечки SAFEARRAY/BSTR/VARIANT в ProcessEnumerator
https://github.com/lintest/VanessaExt/pull/95 fix: утечка HBITMAP в ScreenManager::Capture
https://github.com/lintest/VanessaExt/pull/94 fix: корректное владение HGLOBAL после SetClipboardData