### PR TITLE
Обновление редактора VAEditor, версия 1.3.7.4

### DIFF
--- a/lib/packages.json
+++ b/lib/packages.json
@@ -22,8 +22,8 @@
 "repo": "VAEditor",
 "name": "VAEditor.zip",
 "path": "../VanessaAutomation/Templates/VanessaEditor/Ext/Template.bin",
-"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.7.2/VAEditor.zip",
-"version": "1.3.7.2",
-"hash": "56045FEE2A65F91F1AC24170619116CCABAC8177B57CDE81BD6C5F6D63087CE8"
+"url": "https://github.com/Pr-Mex/VAEditor/releases/download/1.3.7.5/VAEditor.zip",
+"version": "1.3.7.5",
+"hash": "B723B83F3146B3CDF437C47B08561285907C79DFE9838D83AD08E5B3845F9C5A"
 }
 ]


### PR DESCRIPTION
Исправления @OlegKopeykin:
- синхронизация документации со скриптами и именами файлов
- включить tsconfig noImplicitReturns
- обновить webpack-dev-server 3.11.3 → 4.15.2
- обновить build/test зависимости и поднять минимум Node до 20
- опубликовать .d.ts контракт публичного API
- поднять минимум сборки до ES2015
- удалить мёртвые devDependencies
- удалить Babel 6 из сборки
- удалить мёртвый код и неиспользуемые импорты
- удалить остатки Jest из devDependencies